### PR TITLE
feat: mapstruct 라이브러리 추가 및 application.yml 불필요한 설정 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,10 +76,23 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
+	// mapstruct
+	implementation 'org.mapstruct:mapstruct:1.6.3'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+	testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.6.3"
+
 	// junit
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// test container
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile) {
+	options.compilerArgs += ['-Amapstruct.defaultComponentModel=spring']
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,6 +35,7 @@ spring:
         use_sql_comments: true
         format_sql: true
         show_sql: true
+
   mail:
     host: ${MAIL_POST_PROD}
     port: ${MAIL_PORT_PROD}
@@ -63,7 +64,3 @@ server:
       charset: UTF-8
       enabled: true
       force: true
-
-logging:
-  level:
-    org.hibernate.SQL: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,10 +63,6 @@ server:
       enabled: true
       force: true
 
-logging:
-  level:
-    org.hibernate.SQL: debug
-
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
Closes #9 

## 🔥 작업 내용  
- `build.gradle`에 mapstruct 라이브러리 추가
- `build.gradle`에 testcontainer 라이브러리 추가
- `application.yml`, `application-prod.yml`에 `logging.level.org.hibernate.SQL` 옵션 삭제

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #9 
