### PR TITLE
feat: 주문 기본 CRUD 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local environment file ###
+.env

--- a/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
@@ -1,0 +1,25 @@
+package com.harusari.chainware.order.command.application.controller;
+
+import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
+import com.harusari.chainware.order.command.application.service.OrderCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OrderCommandController {
+
+    private final OrderCommandService orderCommandService;
+
+    // 주문 등록
+    @PostMapping("/orders")
+    public ResponseEntity<ApiResponse<OrderCommandResponse>> createOrder(@RequestBody OrderCreateRequest request) {
+        OrderCommandResponse response = orderCommandService.createOrder(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.order.command.application.controller;
 
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.request.OrderUpdateRequest;
 import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
 import com.harusari.chainware.order.command.application.service.OrderCommandService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,16 @@ public class OrderCommandController {
     @PostMapping("/orders")
     public ResponseEntity<ApiResponse<OrderCommandResponse>> createOrder(@RequestBody OrderCreateRequest request) {
         OrderCommandResponse response = orderCommandService.createOrder(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 주문 수정
+    @PutMapping("/orders/{orderId}")
+    public ResponseEntity<ApiResponse<OrderCommandResponse>> updateOrder(
+            @PathVariable Long orderId,
+            @RequestBody OrderUpdateRequest request
+    ) {
+        OrderCommandResponse response = orderCommandService.updateOrder(orderId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.order.command.application.controller;
 
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.request.OrderRejectRequest;
 import com.harusari.chainware.order.command.application.dto.request.OrderUpdateRequest;
 import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
 import com.harusari.chainware.order.command.application.service.OrderCommandService;
@@ -21,6 +22,7 @@ public class OrderCommandController {
     public ResponseEntity<ApiResponse<OrderCommandResponse>> createOrder(
             @RequestBody OrderCreateRequest request
     ) {
+        System.out.println("createOrder 메소드 실행");
         OrderCommandResponse response = orderCommandService.createOrder(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -36,7 +38,31 @@ public class OrderCommandController {
     }
 
     // 주문 취소
+    @PutMapping("/orders/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<OrderCommandResponse>> cancelOrder(
+            @PathVariable Long orderId
+    ) {
+        OrderCommandResponse response = orderCommandService.cancelOrder(orderId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
-    // 주문 승인, 반려
+    // 주문 승인
+    @PutMapping("/orders/{orderId}/approve")
+    public ResponseEntity<ApiResponse<OrderCommandResponse>> approveOrder(
+            @PathVariable Long orderId
+    ) {
+        OrderCommandResponse response = orderCommandService.approveOrder(orderId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 주문 반려
+    @PutMapping("/orders/{orderId}/reject")
+    public ResponseEntity<ApiResponse<OrderCommandResponse>> rejectOrder(
+            @PathVariable Long orderId,
+            @RequestBody OrderRejectRequest request
+    ) {
+        OrderCommandResponse response = orderCommandService.rejectOrder(orderId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
@@ -18,7 +18,9 @@ public class OrderCommandController {
 
     // 주문 등록
     @PostMapping("/orders")
-    public ResponseEntity<ApiResponse<OrderCommandResponse>> createOrder(@RequestBody OrderCreateRequest request) {
+    public ResponseEntity<ApiResponse<OrderCommandResponse>> createOrder(
+            @RequestBody OrderCreateRequest request
+    ) {
         OrderCommandResponse response = orderCommandService.createOrder(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -32,5 +34,9 @@ public class OrderCommandController {
         OrderCommandResponse response = orderCommandService.updateOrder(orderId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    // 주문 취소
+
+    // 주문 승인, 반려
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
@@ -6,9 +6,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class OrderCreateRequest {
     private Long franchiseId;
     private Long memberId;

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.order.command.application.dto.request;
 
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -9,7 +10,10 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class OrderCreateRequest {
-    private Long storeId;
+    private Long franchiseId;
+    private Long memberId;
+    private LocalDate deliveryDueDate;
     private List<OrderDetailCreateRequest> orderDetails;
 }
+
 

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.order.command.application.dto.request;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderCreateRequest {
+    private Long storeId;
+    private List<OrderDetailCreateRequest> orderDetails;
+}
+

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailCreateRequest.java
@@ -1,14 +1,8 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class OrderDetailCreateRequest {
     private Long productId;
     private Integer quantity;

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailCreateRequest.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.order.command.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderDetailCreateRequest {
+    private Long productId;
+    private Integer quantity;
+}

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailUpdateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailUpdateRequest.java
@@ -1,14 +1,8 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class OrderDetailUpdateRequest {
     private Long productId;
     private Integer quantity;

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailUpdateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.order.command.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderDetailUpdateRequest {
+    private Long productId;
+    private Integer quantity;
+}

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderRejectRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderRejectRequest.java
@@ -1,14 +1,8 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class OrderRejectRequest {
     private String rejectReason;
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderRejectRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderRejectRequest.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.order.command.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderRejectRequest {
+    private String rejectReason;
+}
+

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderUpdateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.harusari.chainware.order.command.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderUpdateRequest {
+    private List<OrderDetailUpdateRequest> orderDetails;
+}

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderUpdateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderUpdateRequest.java
@@ -1,16 +1,10 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class OrderUpdateRequest {
     private List<OrderDetailUpdateRequest> orderDetails;
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/response/OrderCommandResponse.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/response/OrderCommandResponse.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.order.command.application.dto.response;
 
+import com.harusari.chainware.order.command.domain.aggregate.OrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +14,8 @@ import java.time.LocalDateTime;
 @Builder
 public class OrderCommandResponse {
     private Long orderId;
-    private Long storeId;
-    private String orderStatus;
-    private LocalDateTime orderedAt;
+    private Long franchiseId;
+    private OrderStatus orderStatus;
+    private LocalDateTime createdAt;
 }
 

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/response/OrderCommandResponse.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/response/OrderCommandResponse.java
@@ -1,0 +1,20 @@
+package com.harusari.chainware.order.command.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderCommandResponse {
+    private Long orderId;
+    private Long storeId;
+    private String orderStatus;
+    private LocalDateTime orderedAt;
+}
+

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/response/OrderCommandResponse.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/response/OrderCommandResponse.java
@@ -1,16 +1,12 @@
 package com.harusari.chainware.order.command.application.dto.response;
 
 import com.harusari.chainware.order.command.domain.aggregate.OrderStatus;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class OrderCommandResponse {
     private Long orderId;

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
@@ -1,10 +1,13 @@
 package com.harusari.chainware.order.command.application.service;
 
 import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.request.OrderUpdateRequest;
 import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
 
 public interface OrderCommandService {
 
     OrderCommandResponse createOrder(OrderCreateRequest request);
+
+    OrderCommandResponse updateOrder(Long orderId, OrderUpdateRequest request);
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
@@ -1,6 +1,7 @@
 package com.harusari.chainware.order.command.application.service;
 
 import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.request.OrderRejectRequest;
 import com.harusari.chainware.order.command.application.dto.request.OrderUpdateRequest;
 import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
 
@@ -9,5 +10,11 @@ public interface OrderCommandService {
     OrderCommandResponse createOrder(OrderCreateRequest request);
 
     OrderCommandResponse updateOrder(Long orderId, OrderUpdateRequest request);
+
+    OrderCommandResponse cancelOrder(Long orderId);
+
+    OrderCommandResponse approveOrder(Long orderId);
+
+    OrderCommandResponse rejectOrder(Long orderId, OrderRejectRequest request);
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
@@ -1,0 +1,10 @@
+package com.harusari.chainware.order.command.application.service;
+
+import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
+
+public interface OrderCommandService {
+
+    OrderCommandResponse createOrder(OrderCreateRequest request);
+
+}

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
@@ -202,6 +202,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 .build();
     }
 
+    // 주문 승인
     @Override
     public OrderCommandResponse approveOrder(Long orderId) {
 
@@ -227,6 +228,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 .build();
     }
 
+    // 주문 반려
     @Override
     public OrderCommandResponse rejectOrder(Long orderId, OrderRejectRequest request) {
 
@@ -253,6 +255,5 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 .createdAt(order.getCreatedAt())
                 .build();
     }
-
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
@@ -1,10 +1,12 @@
 package com.harusari.chainware.order.command.application.service;
 
 import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.request.OrderDetailCreateRequest;
 import com.harusari.chainware.order.command.application.dto.request.OrderUpdateRequest;
 import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
 import com.harusari.chainware.order.command.domain.aggregate.Order;
 import com.harusari.chainware.order.command.domain.aggregate.OrderDetail;
+import com.harusari.chainware.order.command.domain.aggregate.OrderStatus;
 import com.harusari.chainware.order.command.domain.repository.OrderDetailRepository;
 import com.harusari.chainware.order.command.domain.repository.OrderRepository;
 import com.harusari.chainware.order.exception.OrderErrorCode;
@@ -13,7 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -24,39 +29,95 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     private final OrderRepository orderRepository;
     private final OrderDetailRepository orderDetailRepository;
 
+    // 주문 등록
     @Override
     public OrderCommandResponse createOrder(OrderCreateRequest request) {
 
-        // 1. 주문 엔티티 생성 및 저장 (상태는 'REQUESTED', 현재 시간 기준)
+        // 1. 가격 계산용 변수
+        int productCount = request.getOrderDetails().size();
+        int totalQuantity = 0;
+        long totalPrice = 0L;
+
+        List<OrderDetail> details = new ArrayList<>();
+
+        for (OrderDetailCreateRequest d : request.getOrderDetails()) {
+            // TODO: productService 등으로 상품 가격 조회
+            // int unitPrice = getProductPrice(d.getProductId());
+            int unitPrice = 1500;
+
+            int quantity = d.getQuantity();
+            long itemTotalPrice = (long) unitPrice * quantity;
+
+            totalQuantity += quantity;
+            totalPrice += itemTotalPrice;
+
+            details.add(OrderDetail.builder()
+                    .orderId(null) // 일단 비워두고 나중에 채움
+                    .productId(d.getProductId())
+                    .quantity(quantity)
+                    .unitPrice(unitPrice)
+                    .totalPrice(itemTotalPrice)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+        }
+
+        // 2. 주문 엔티티 생성 및 저장
         Order order = Order.builder()
-                .storeId(request.getStoreId())
-                .orderStatus("REQUESTED")
-                .orderedAt(LocalDateTime.now())
-                .isDeleted(false)
+                .franchiseId(request.getFranchiseId())
+                .memberId(request.getMemberId())
+                .orderCode(generateOrderCode())
+                .deliveryDueDate(request.getDeliveryDueDate())
+                .productCount(productCount)
+                .totalQuantity(totalQuantity)
+                .totalPrice(totalPrice)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
                 .build();
 
         Order savedOrder = orderRepository.save(order);
 
-        // 2. 주문 상세 생성 및 저장
-        List<OrderDetail> details = request.getOrderDetails().stream()
-                .map(d -> OrderDetail.builder()
+        // 3. 주문 ID 반영해서 상세 저장
+        List<OrderDetail> finalDetails = details.stream()
+                .map(detail -> OrderDetail.builder()
                         .orderId(savedOrder.getOrderId())
-                        .productId(d.getProductId())
-                        .quantity(d.getQuantity())
+                        .productId(detail.getProductId())
+                        .quantity(detail.getQuantity())
+                        .unitPrice(detail.getUnitPrice())
+                        .totalPrice(detail.getTotalPrice())
+                        .createdAt(detail.getCreatedAt())
                         .build())
                 .toList();
 
-        orderDetailRepository.saveAll(details);
+        orderDetailRepository.saveAll(finalDetails);
 
-        // 3. 저장된 주문 정보를 응답 DTO로 변환하여 반환
+
         return OrderCommandResponse.builder()
                 .orderId(savedOrder.getOrderId())
-                .storeId(savedOrder.getStoreId())
+                .franchiseId(savedOrder.getFranchiseId())
                 .orderStatus(savedOrder.getOrderStatus())
-                .orderedAt(savedOrder.getOrderedAt())
+                .createdAt(savedOrder.getCreatedAt())
                 .build();
     }
 
+    // 주문 코드 생성
+    private String generateOrderCode() {
+
+        LocalDate today = LocalDate.now();
+        String datePart = today.format(DateTimeFormatter.ofPattern("yyMMdd"));
+
+        // 오늘 날짜의 기존 주문 수 조회
+        long count = orderRepository.countByCreatedAtBetween(
+                today.atStartOfDay(),
+                today.plusDays(1).atStartOfDay()
+        );
+
+        // 코드 중 시퀀스값 계산
+        String sequencePart = String.format("%03d", count + 1);
+
+        return "SO-" + datePart + sequencePart;
+    }
+
+    // 주문 수정
     @Override
     public OrderCommandResponse updateOrder(Long orderId, OrderUpdateRequest request) {
 
@@ -65,7 +126,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 .orElseThrow(() -> new OrderUpdateInvalidException(OrderErrorCode.ORDER_UPDATE_INVALID));
 
         // 2. 상태 검증
-        if (!"REQUESTED".equals(order.getOrderStatus())) {
+        if (OrderStatus.REQUESTED.equals(order.getOrderStatus())) {
             throw new OrderUpdateInvalidException(OrderErrorCode.ORDER_UPDATE_INVALID);
         }
 
@@ -85,9 +146,9 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         // 5. 응답
         return OrderCommandResponse.builder()
                 .orderId(order.getOrderId())
-                .storeId(order.getStoreId())
+                .franchiseId(order.getFranchiseId())
                 .orderStatus(order.getOrderStatus())
-                .orderedAt(order.getOrderedAt())
+                .createdAt(order.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
@@ -1,0 +1,57 @@
+package com.harusari.chainware.order.command.application.service;
+
+import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
+import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
+import com.harusari.chainware.order.command.domain.aggregate.Order;
+import com.harusari.chainware.order.command.domain.aggregate.OrderDetail;
+import com.harusari.chainware.order.command.domain.repository.OrderDetailRepository;
+import com.harusari.chainware.order.command.domain.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderCommandServiceImpl implements OrderCommandService {
+
+    private final OrderRepository orderRepository;
+    private final OrderDetailRepository orderDetailRepository;
+
+    @Override
+    public OrderCommandResponse createOrder(OrderCreateRequest request) {
+
+        // 1. 주문 엔티티 생성 및 저장 (상태는 'REQUESTED', 현재 시간 기준)
+        Order order = Order.builder()
+                .storeId(request.getStoreId())
+                .orderStatus("REQUESTED")
+                .orderedAt(LocalDateTime.now())
+                .isDeleted(false)
+                .build();
+
+        Order savedOrder = orderRepository.save(order);
+
+        // 2. 주문 상세 생성 및 저장
+        List<OrderDetail> details = request.getOrderDetails().stream()
+                .map(d -> OrderDetail.builder()
+                        .orderId(savedOrder.getOrderId())
+                        .productId(d.getProductId())
+                        .quantity(d.getQuantity())
+                        .build())
+                .toList();
+
+        orderDetailRepository.saveAll(details);
+
+        // 3. 저장된 주문 정보를 응답 DTO로 변환하여 반환
+        return OrderCommandResponse.builder()
+                .orderId(savedOrder.getOrderId())
+                .storeId(savedOrder.getStoreId())
+                .orderStatus(savedOrder.getOrderStatus())
+                .orderedAt(savedOrder.getOrderedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
@@ -54,4 +54,12 @@ public class Order {
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
 
+    public void update(int productCount, int totalQuantity, long totalPrice, LocalDateTime modifiedAt) {
+        this.productCount = productCount;
+        this.totalQuantity = totalQuantity;
+        this.totalPrice = totalPrice;
+        this.modifiedAt = modifiedAt;
+    }
+
+
 }

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.order.command.domain.aggregate;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -18,19 +19,39 @@ public class Order {
     @Column(name = "store_order_id")
     private Long orderId;
 
-    @Column(name = "store_id", nullable = false)
-    private Long storeId;
+    @Column(name = "franchise_id", nullable = false)
+    private Long franchiseId;
 
-    @Column(name = "order_status", nullable = false)
-    private String orderStatus;
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
-    @Column(name = "ordered_at", nullable = false)
-    private LocalDateTime orderedAt;
+    @Column(name = "store_order_code", nullable = false, length = 50)
+    private String orderCode;
+
+    @Column(name = "delivery_due_date", nullable = false)
+    private LocalDate deliveryDueDate;
+
+    @Column(name = "product_count", nullable = false)
+    private Integer productCount;
+
+    @Column(name = "total_quantity", nullable = false)
+    private Integer totalQuantity;
+
+    @Column(name = "total_price", nullable = false)
+    private Long totalPrice;
+
+    @Column(name = "store_order_status", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+
+
+    @Column(name = "reject_reason")
+    private String rejectReason;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
-
-    @Column(name = "is_deleted")
-    private Boolean isDeleted;
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
@@ -1,0 +1,36 @@
+package com.harusari.chainware.order.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "store_order")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_order_id")
+    private Long orderId;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(name = "order_status", nullable = false)
+    private String orderStatus;
+
+    @Column(name = "ordered_at", nullable = false)
+    private LocalDateTime orderedAt;
+
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "is_deleted")
+    private Boolean isDeleted;
+
+}

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
@@ -61,5 +61,10 @@ public class Order {
         this.modifiedAt = modifiedAt;
     }
 
+    public void changeStatus(OrderStatus status, String rejectReason, LocalDateTime modifiedAt) {
+        this.orderStatus = status;
+        this.rejectReason = rejectReason;
+        this.modifiedAt = modifiedAt;
+    }
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
@@ -10,8 +10,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "store_order")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class Order {
 
     @Id
@@ -53,6 +51,22 @@ public class Order {
 
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
+
+    @Builder
+    public Order(Long franchiseId, Long memberId, String orderCode, LocalDate deliveryDueDate,
+                 Integer productCount, Integer totalQuantity, Long totalPrice,
+                 OrderStatus orderStatus, String rejectReason, LocalDateTime createdAt) {
+        this.franchiseId = franchiseId;
+        this.memberId = memberId;
+        this.orderCode = orderCode;
+        this.deliveryDueDate = deliveryDueDate;
+        this.productCount = productCount;
+        this.totalQuantity = totalQuantity;
+        this.totalPrice = totalPrice;
+        this.orderStatus = orderStatus;
+        this.rejectReason = rejectReason;
+        this.createdAt = createdAt;
+    }
 
     public void update(int productCount, int totalQuantity, long totalPrice, LocalDateTime modifiedAt) {
         this.productCount = productCount;

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderDetail.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderDetail.java
@@ -3,6 +3,8 @@ package com.harusari.chainware.order.command.domain.aggregate;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Entity
 @Table(name = "store_order_detail")
@@ -24,5 +26,14 @@ public class OrderDetail {
 
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
+
+    @Column(name = "unit_price", nullable = false)
+    private Integer unitPrice;
+
+    @Column(name = "total_price", nullable = false)
+    private Long totalPrice;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderDetail.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderDetail.java
@@ -1,0 +1,28 @@
+package com.harusari.chainware.order.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Table(name = "store_order_detail")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class OrderDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_order_detail_id")
+    private Long orderDetailId;
+
+    @Column(name = "store_order_id")
+    private Long orderId;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+}

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderDetail.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderDetail.java
@@ -9,8 +9,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "store_order_detail")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class OrderDetail {
 
     @Id
@@ -35,5 +33,15 @@ public class OrderDetail {
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+
+    @Builder
+    public OrderDetail(Long orderId, Long productId, Integer quantity, Integer unitPrice, Long totalPrice, LocalDateTime createdAt) {
+        this.orderId = orderId;
+        this.productId = productId;
+        this.quantity = quantity;
+        this.unitPrice = unitPrice;
+        this.totalPrice = totalPrice;
+        this.createdAt = createdAt;
+    }
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderStatus.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.harusari.chainware.order.command.domain.aggregate;
+
+public enum OrderStatus {
+    REQUESTED,
+    CANCELLED,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderDetailRepository.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderDetailRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
 
+    void deleteAllByOrderId(Long orderId);
+
 }

--- a/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderDetailRepository.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderDetailRepository.java
@@ -1,0 +1,8 @@
+package com.harusari.chainware.order.command.domain.repository;
+
+import com.harusari.chainware.order.command.domain.aggregate.OrderDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
+
+}

--- a/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderRepository.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.harusari.chainware.order.command.domain.repository;
+
+import com.harusari.chainware.order.command.domain.aggregate.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderRepository.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/repository/OrderRepository.java
@@ -3,6 +3,10 @@ package com.harusari.chainware.order.command.domain.repository;
 import com.harusari.chainware.order.command.domain.aggregate.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 
 }

--- a/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 public enum OrderErrorCode {
 
     ORDER_UPDATE_INVALID("10001", "수정 가능한 상태가 아닙니다.", HttpStatus.BAD_REQUEST),
+    REJECT_REASON_REQUIRED("10002", "반려 사유가 필요합니다.", HttpStatus.BAD_REQUEST),
     METHOD_ARG_NOT_VALID("10999", "@Valid 검증 오류입니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;

--- a/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
@@ -1,0 +1,34 @@
+package com.harusari.chainware.order.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode {
+
+    ORDER_UPDATE_INVALID("10001", "수정 가능한 상태가 아닙니다.", HttpStatus.BAD_REQUEST),
+    METHOD_ARG_NOT_VALID("10999", "@Valid 검증 오류입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+    private static final Map<String, OrderErrorCode> MESSAGE_TO_ENUM;
+
+    static {
+        MESSAGE_TO_ENUM = Arrays.stream(values())
+                .collect(Collectors.toMap(OrderErrorCode::getErrorMessage, e -> e));
+    }
+
+    public static Optional<OrderErrorCode> fromMessage(String message) {
+        return Optional.ofNullable(MESSAGE_TO_ENUM.get(message));
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/order/exception/OrderUpdateInvalidException.java
+++ b/src/main/java/com/harusari/chainware/order/exception/OrderUpdateInvalidException.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.order.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OrderUpdateInvalidException extends RuntimeException {
+
+    private final OrderErrorCode errorCode;
+
+    public OrderUpdateInvalidException(OrderErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/order/exception/handler/OrderExceptionHandler.java
+++ b/src/main/java/com/harusari/chainware/order/exception/handler/OrderExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.harusari.chainware.order.exception.handler;
+
+import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.order.exception.OrderErrorCode;
+import com.harusari.chainware.order.exception.OrderUpdateInvalidException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class OrderExceptionHandler {
+
+    @ExceptionHandler(OrderUpdateInvalidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUpdateInvalidException(OrderUpdateInvalidException e) {
+        OrderErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+}


### PR DESCRIPTION
Closes #8

## 🔥 작업 내용  
- 주문 등록, 수정, 취소, 승인, 반려 기능을 위한 기본 API 구현. 다른 컨텍스트와 연결되는 부분은 아직 미완.
- 주문 상태(OrderStatus)는 REQUESTED, APPROVED, REJECTED, CANCELLED로 관리됨
- 각 상태별 유효성 검사 및 예외 처리 일부 적용
- 주문 생성 시 주문코드는 "SO-yyMMddXXX" 포맷으로 자동 생성되며, 당일 생성 수 기반 시퀀스 포함
- 주문 상세(OrderDetail)는 함께 등록되며, 상품 가격은 임시 고정값(1500) 사용
- 추후 ProductService, InventoryService와 연동을 위한 TODO 주석 추가 (디벨롭해야 함)

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ⚙️ 특이사항
- .gitignore에 .env 추가하였으므로 프로젝트에서 .env 관리 가능.

## ✨ 관련 이슈
- #8