### PR TITLE
feat: 가맹점/창고/반품 폐기 등록 및 가맹점 관리자/창고 관리자/ 일반,책임 관리자 폐기 조회

### DIFF
--- a/src/main/java/com/harusari/chainware/disposal/command/application/controller/DisposalCommandController.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/application/controller/DisposalCommandController.java
@@ -1,0 +1,46 @@
+package com.harusari.chainware.disposal.command.application.controller;
+
+import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.disposal.command.application.dto.DisposalCommandRequestDto;
+import com.harusari.chainware.disposal.command.application.service.DisposalCommandService;
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/disposal")
+@RequiredArgsConstructor
+public class DisposalCommandController {
+
+    private final DisposalCommandService disposalCommandService;
+
+    /*
+        @PostMapping
+        public ResponseEntity<ApiResponse<Void>> registerDisposal(
+                @RequestBody DisposalCommandRequestDto request,
+                @AuthenticationPrincipal CustomUserDetails userDetails
+        ) {
+            Long memberId = userDetails.getMemberId();
+            MemberAuthorityType authorityType = userDetails.getAuthorityType();
+
+            disposalCommandService.registerDisposal(request, memberId, authorityType);
+            return ResponseEntity.ok(ApiResponse.success(null));
+        }
+    */
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> registerDisposal(
+            @RequestBody DisposalCommandRequestDto request
+    ) {
+        // 임시 하드코딩된 사용자 정보
+        Long memberId = 1L;
+        MemberAuthorityType authorityType = MemberAuthorityType.FRANCHISE_MANAGER;
+
+        disposalCommandService.registerDisposal(request, memberId, authorityType);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/harusari/chainware/disposal/command/application/dto/DisposalCommandRequestDto.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/application/dto/DisposalCommandRequestDto.java
@@ -1,0 +1,14 @@
+package com.harusari.chainware.disposal.command.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DisposalCommandRequestDto {
+
+    private Long productId;
+    private Long takeBackId;
+    private Integer quantity;
+    private String disposalReason;
+}

--- a/src/main/java/com/harusari/chainware/disposal/command/application/service/DisposalCommandService.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/application/service/DisposalCommandService.java
@@ -1,0 +1,11 @@
+package com.harusari.chainware.disposal.command.application.service;
+
+import com.harusari.chainware.disposal.command.application.dto.DisposalCommandRequestDto;
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface DisposalCommandService {
+
+    @Transactional
+    void registerDisposal(DisposalCommandRequestDto request, Long memberId, MemberAuthorityType authorityType);
+}

--- a/src/main/java/com/harusari/chainware/disposal/command/application/service/DisposalCommandService.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/application/service/DisposalCommandService.java
@@ -2,10 +2,8 @@ package com.harusari.chainware.disposal.command.application.service;
 
 import com.harusari.chainware.disposal.command.application.dto.DisposalCommandRequestDto;
 import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface DisposalCommandService {
 
-    @Transactional
     void registerDisposal(DisposalCommandRequestDto request, Long memberId, MemberAuthorityType authorityType);
 }

--- a/src/main/java/com/harusari/chainware/disposal/command/application/service/DisposalCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/application/service/DisposalCommandServiceImpl.java
@@ -1,0 +1,52 @@
+package com.harusari.chainware.disposal.command.application.service;
+
+import com.harusari.chainware.disposal.command.application.dto.DisposalCommandRequestDto;
+import com.harusari.chainware.disposal.command.domain.aggregate.Disposal;
+import com.harusari.chainware.disposal.command.infrastructure.repository.JpaDisposalRepository;
+import com.harusari.chainware.franchise.command.infrastructure.repository.JpaFranchiseRepository;
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import com.harusari.chainware.warehouse.command.infrastructure.repository.JpaWarehouseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DisposalCommandServiceImpl implements DisposalCommandService {
+
+    private final JpaDisposalRepository disposalRepository;
+    private final JpaFranchiseRepository franchiseRepository;
+    private final JpaWarehouseRepository warehouseRepository;
+
+    @Transactional
+    @Override
+    public void registerDisposal(DisposalCommandRequestDto request, Long memberId, MemberAuthorityType authorityType) {
+        Long franchiseId = null;
+        Long warehouseId = null;
+
+        switch (authorityType) {
+            case FRANCHISE_MANAGER -> {
+                franchiseId = franchiseRepository.findFranchiseIdByMemberId(memberId)
+                        .orElseThrow(() -> new RuntimeException("해당 가맹점 정보를 찾을 수 없습니다.")).getFranchiseId();
+            }
+            case WAREHOUSE_MANAGER -> {
+                warehouseId = warehouseRepository.findWarehouseIdByMemberId(memberId)
+                        .orElseThrow(() -> new RuntimeException("해당 창고 정보를 찾을 수 없습니다.")).getWarehouseId();
+            }
+            default -> throw new RuntimeException("폐기를 등록할 권한이 없습니다.");
+        }
+
+        Disposal disposal = Disposal.builder()
+                .productId(request.getProductId())
+                .warehouseId(warehouseId)
+                .franchiseId(franchiseId)
+                .takeBackId(request.getTakeBackId())
+                .quantity(request.getQuantity())
+                .disposalReason(request.getDisposalReason())
+                .build();
+
+        disposalRepository.save(disposal);
+
+        // TODO: 재고 감소 처리 (추후 구현)
+    }
+}

--- a/src/main/java/com/harusari/chainware/disposal/command/domain/aggregate/Disposal.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/domain/aggregate/Disposal.java
@@ -1,0 +1,60 @@
+package com.harusari.chainware.disposal.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "disposal")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Disposal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "disposal_id")
+    private Long disposalId;
+
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Column(name = "warehouse_id")
+    private Long warehouseId;
+
+    @Column(name = "franchise_id")
+    private Long franchiseId;
+
+    @Column(name = "take_back_id")
+    private Long takeBackId;
+
+    @Column(name = "quantity")
+    private Integer quantity;
+
+    @Column(name = "disposal_reason")
+    private String disposalReason;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Disposal(Long productId, Long warehouseId, Long franchiseId, Long takeBackId, Integer quantity, String disposalReason, LocalDateTime createdAt) {
+        this.productId = productId;
+        this.warehouseId = warehouseId;
+        this.franchiseId = franchiseId;
+        this.takeBackId = takeBackId;
+        this.quantity = quantity;
+        this.disposalReason = disposalReason;
+        this.createdAt = createdAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/harusari/chainware/disposal/command/domain/repository/DisposalRepository.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/domain/repository/DisposalRepository.java
@@ -1,0 +1,4 @@
+package com.harusari.chainware.disposal.command.domain.repository;
+
+public interface DisposalRepository {
+}

--- a/src/main/java/com/harusari/chainware/disposal/command/infrastructure/repository/JpaDisposalRepository.java
+++ b/src/main/java/com/harusari/chainware/disposal/command/infrastructure/repository/JpaDisposalRepository.java
@@ -1,0 +1,8 @@
+package com.harusari.chainware.disposal.command.infrastructure.repository;
+
+import com.harusari.chainware.disposal.command.domain.aggregate.Disposal;
+import com.harusari.chainware.disposal.command.domain.repository.DisposalRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaDisposalRepository extends DisposalRepository, JpaRepository<Disposal, Long> {
+}

--- a/src/main/java/com/harusari/chainware/disposal/query/controller/DisposalQueryController.java
+++ b/src/main/java/com/harusari/chainware/disposal/query/controller/DisposalQueryController.java
@@ -1,0 +1,47 @@
+package com.harusari.chainware.disposal.query.controller;
+
+import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.disposal.query.dto.DisposalListResponseDto;
+import com.harusari.chainware.disposal.query.dto.DisposalSearchRequestDto;
+import com.harusari.chainware.disposal.query.service.DisposalQueryService;
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/disposal")
+@RequiredArgsConstructor
+public class DisposalQueryController {
+
+    private final DisposalQueryService disposalQueryService;
+/*
+    @GetMapping
+    public ResponseEntity<ApiResponse<DisposalListResponseDto>> getDisposals(
+            @ModelAttribute DisposalSearchRequestDto request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getMemberId();
+        MemberAuthorityType authorityType = userDetails.getAuthorityType();
+
+        DisposalListResponseDto result = disposalQueryService.getDisposals(request, memberId, authorityType);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+*/
+    @GetMapping
+    public ResponseEntity<ApiResponse<DisposalListResponseDto>> getDisposals(
+            @ModelAttribute DisposalSearchRequestDto request
+    ) {
+        Long memberId = 1L;
+        MemberAuthorityType authorityType = MemberAuthorityType.GENERAL_MANAGER;
+
+        DisposalListResponseDto result = disposalQueryService.getDisposals(request, memberId, authorityType);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/harusari/chainware/disposal/query/dto/DisposalListDto.java
+++ b/src/main/java/com/harusari/chainware/disposal/query/dto/DisposalListDto.java
@@ -1,0 +1,20 @@
+package com.harusari.chainware.disposal.query.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class DisposalListDto {
+
+    private Long disposalId;
+    private String franchiseName;
+    private String warehouseName;
+    private String productName;
+    private String productCode;
+    private Integer quantity;
+    private String disposalReason;
+    private LocalDateTime createdAt;
+    private Long takeBackId;
+
+}

--- a/src/main/java/com/harusari/chainware/disposal/query/dto/DisposalListResponseDto.java
+++ b/src/main/java/com/harusari/chainware/disposal/query/dto/DisposalListResponseDto.java
@@ -1,0 +1,14 @@
+package com.harusari.chainware.disposal.query.dto;
+
+import com.harusari.chainware.common.dto.Pagination;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DisposalListResponseDto {
+    private final List<DisposalListDto> items;
+    private final Pagination pagination;
+}

--- a/src/main/java/com/harusari/chainware/disposal/query/dto/DisposalSearchRequestDto.java
+++ b/src/main/java/com/harusari/chainware/disposal/query/dto/DisposalSearchRequestDto.java
@@ -1,0 +1,26 @@
+package com.harusari.chainware.disposal.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DisposalSearchRequestDto {
+    private Integer page = 1;
+    private Integer size = 10;
+
+    private String franchiseName;
+    private String warehouseName;
+    private String productName;
+    private String topCategoryName;
+    private String categoryName;
+    private String disposalType; // 예: "NORMAL"(창고 폐기), "RETURN"(반품 폐기)
+
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+
+    public int getLimit() {
+        return size;
+    }
+}

--- a/src/main/java/com/harusari/chainware/disposal/query/mapper/DisposalQueryMapper.java
+++ b/src/main/java/com/harusari/chainware/disposal/query/mapper/DisposalQueryMapper.java
@@ -1,0 +1,24 @@
+package com.harusari.chainware.disposal.query.mapper;
+
+import com.harusari.chainware.disposal.query.dto.DisposalListDto;
+import com.harusari.chainware.disposal.query.dto.DisposalSearchRequestDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface DisposalQueryMapper {
+    List<DisposalListDto> findDisposals(
+            @Param("request") DisposalSearchRequestDto request,
+            @Param("franchiseId") Long franchiseId,
+            @Param("warehouseId") Long warehouseId
+    );
+
+    long countDisposals(
+            @Param("request") DisposalSearchRequestDto request,
+            @Param("franchiseId") Long franchiseId,
+            @Param("warehouseId") Long warehouseId
+    );
+
+}

--- a/src/main/java/com/harusari/chainware/disposal/query/service/DisposalQueryService.java
+++ b/src/main/java/com/harusari/chainware/disposal/query/service/DisposalQueryService.java
@@ -1,0 +1,11 @@
+package com.harusari.chainware.disposal.query.service;
+
+import com.harusari.chainware.disposal.query.dto.DisposalListResponseDto;
+import com.harusari.chainware.disposal.query.dto.DisposalSearchRequestDto;
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+
+public interface DisposalQueryService {
+
+    DisposalListResponseDto getDisposals(DisposalSearchRequestDto request, Long memberId, MemberAuthorityType authorityType);
+
+}

--- a/src/main/java/com/harusari/chainware/disposal/query/service/DisposalQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/disposal/query/service/DisposalQueryServiceImpl.java
@@ -1,0 +1,53 @@
+package com.harusari.chainware.disposal.query.service;
+
+import com.harusari.chainware.common.dto.Pagination;
+import com.harusari.chainware.disposal.query.dto.DisposalListDto;
+import com.harusari.chainware.disposal.query.dto.DisposalListResponseDto;
+import com.harusari.chainware.disposal.query.dto.DisposalSearchRequestDto;
+import com.harusari.chainware.disposal.query.mapper.DisposalQueryMapper;
+import com.harusari.chainware.franchise.command.infrastructure.repository.JpaFranchiseRepository;
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import com.harusari.chainware.warehouse.command.infrastructure.repository.JpaWarehouseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DisposalQueryServiceImpl implements DisposalQueryService {
+
+    private final DisposalQueryMapper mapper;
+    private final JpaFranchiseRepository franchiseRepository;
+    private final JpaWarehouseRepository warehouseRepository;
+
+    @Override
+    @Transactional
+    public DisposalListResponseDto getDisposals(DisposalSearchRequestDto request, Long memberId, MemberAuthorityType authorityType) {
+        Long franchiseId = null;
+        Long warehouseId = null;
+
+        switch (authorityType) {
+            case FRANCHISE_MANAGER -> franchiseId = franchiseRepository.findFranchiseIdByMemberId(memberId)
+                    .orElseThrow(() -> new RuntimeException("가맹점 없음")).getFranchiseId();
+            case WAREHOUSE_MANAGER -> warehouseId = warehouseRepository.findWarehouseIdByMemberId(memberId)
+                    .orElseThrow(() -> new RuntimeException("창고 없음")).getWarehouseId();
+            case GENERAL_MANAGER, SENIOR_MANAGER -> {} // 전체 조회
+            default -> throw new RuntimeException("폐기 조회 권한 없음");
+        }
+
+        List<DisposalListDto> items = mapper.findDisposals(request, franchiseId, warehouseId);
+        long totalCount = mapper.countDisposals(request, franchiseId, warehouseId);
+        int totalPages = (int) Math.ceil((double) totalCount / request.getSize());
+
+        return DisposalListResponseDto.builder()
+                .items(items)
+                .pagination(Pagination.builder()
+                        .currentPage(request.getPage())
+                        .totalPages(totalPages)
+                        .totalItems(totalCount)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/harusari/chainware/franchise/command/domain/repository/FranchiseRepository.java
+++ b/src/main/java/com/harusari/chainware/franchise/command/domain/repository/FranchiseRepository.java
@@ -2,8 +2,12 @@ package com.harusari.chainware.franchise.command.domain.repository;
 
 import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
 
+import java.util.Optional;
+
 public interface FranchiseRepository {
 
     Franchise save(Franchise franchise);
+
+    Optional<Franchise> findFranchiseIdByMemberId(Long memberId);
 
 }

--- a/src/main/java/com/harusari/chainware/warehouse/command/domain/repository/WarehouseRepository.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/domain/repository/WarehouseRepository.java
@@ -2,8 +2,12 @@ package com.harusari.chainware.warehouse.command.domain.repository;
 
 import com.harusari.chainware.warehouse.command.domain.aggregate.Warehouse;
 
+import java.util.Optional;
+
 public interface WarehouseRepository {
 
     Warehouse save(Warehouse warehouse);
+
+    Optional<Warehouse> findWarehouseIdByMemberId(Long memberId);
 
 }

--- a/src/main/resources/mappers/disposal/DisposalQueryMapper.xml
+++ b/src/main/resources/mappers/disposal/DisposalQueryMapper.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.harusari.chainware.disposal.query.mapper.DisposalQueryMapper">
+
+    <select id="findDisposals" resultType="com.harusari.chainware.disposal.query.dto.DisposalListDto">
+        SELECT
+        d.disposal_id,
+        f.franchise_name,
+        w.warehouse_name,
+        p.product_name,
+        p.product_code,
+        d.quantity,
+        d.disposal_reason,
+        d.created_at,
+        d.take_back_id
+        FROM disposal d
+        LEFT JOIN franchise f ON d.franchise_id = f.franchise_id
+        LEFT JOIN warehouse w ON d.warehouse_id = w.warehouse_id
+        JOIN product p ON d.product_id = p.product_id
+        LEFT JOIN category c ON p.category_id = c.category_id
+        LEFT JOIN top_category tc ON c.top_category_id = tc.top_category_id
+        WHERE 1 = 1
+
+        <if test="franchiseId != null">
+            AND d.franchise_id = #{franchiseId}
+        </if>
+        <if test="warehouseId != null">
+            AND d.warehouse_id = #{warehouseId}
+        </if>
+        <if test="request.franchiseName != null">
+            AND f.franchise_name LIKE CONCAT('%', #{request.franchiseName}, '%')
+        </if>
+        <if test="request.warehouseName != null">
+            AND w.warehouse_name LIKE CONCAT('%', #{request.warehouseName}, '%')
+        </if>
+        <if test="request.productName != null">
+            AND p.product_name LIKE CONCAT('%', #{request.productName}, '%')
+        </if>
+        <if test="request.topCategoryName != null">
+            AND tc.top_category_name LIKE CONCAT('%', #{request.topCategoryName}, '%')
+        </if>
+        <if test="request.categoryName != null">
+            AND c.category_name LIKE CONCAT('%', #{request.categoryName}, '%')
+        </if>
+        <if test="request.disposalType == 'RETURN'">
+            AND d.take_back_id IS NOT NULL
+        </if>
+        <if test="request.disposalType == 'NORMAL'">
+            AND d.take_back_id IS NULL
+        </if>
+
+        ORDER BY d.created_at DESC
+        LIMIT #{request.limit} OFFSET #{request.offset}
+    </select>
+
+    <select id="countDisposals" resultType="long">
+        SELECT COUNT(*)
+        FROM disposal d
+        LEFT JOIN franchise f ON d.franchise_id = f.franchise_id
+        LEFT JOIN warehouse w ON d.warehouse_id = w.warehouse_id
+        JOIN product p ON d.product_id = p.product_id
+        LEFT JOIN category c ON p.category_id = c.category_id
+        LEFT JOIN top_category tc ON c.top_category_id = tc.top_category_id
+        WHERE 1 = 1
+
+        <if test="franchiseId != null">
+            AND d.franchise_id = #{franchiseId}
+        </if>
+        <if test="warehouseId != null">
+            AND d.warehouse_id = #{warehouseId}
+        </if>
+        <if test="request.franchiseName != null">
+            AND f.franchise_name LIKE CONCAT('%', #{request.franchiseName}, '%')
+        </if>
+        <if test="request.warehouseName != null">
+            AND w.warehouse_name LIKE CONCAT('%', #{request.warehouseName}, '%')
+        </if>
+        <if test="request.productName != null">
+            AND p.product_name LIKE CONCAT('%', #{request.productName}, '%')
+        </if>
+        <if test="request.topCategoryName != null">
+            AND tc.top_category_name LIKE CONCAT('%', #{request.topCategoryName}, '%')
+        </if>
+        <if test="request.categoryName != null">
+            AND c.category_name LIKE CONCAT('%', #{request.categoryName}, '%')
+        </if>
+        <if test="request.disposalType == 'RETURN'">
+            AND d.take_back_id IS NOT NULL
+        </if>
+        <if test="request.disposalType == 'NORMAL'">
+            AND d.take_back_id IS NULL
+        </if>
+    </select>
+
+</mapper>


### PR DESCRIPTION
Closes #22 

## 🔥 작업 내용  
- 가맹점/창고/반품 폐기 등록 및 가맹점 관리자/창고 관리자/ 일반,책임 관리자 폐기 조회

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [ ] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ⚙️ 특이사항
- 추후 프론트엔드에서 권한 별 검색조건 hidden 처리
- DisposalCommandServiceImpl에 폐기 처리 시 재고 감소 처리 부분은 별도의 서비스에서 처리해야 함

## ✨ 관련 이슈
- #22 
