### PR TITLE
refactor: 회원 이메일 중복 확인 시 탈퇴 여부 조건 제거 및 회원 조회 쿼리에 탈퇴 여부 조건 추가

### DIFF
--- a/src/main/java/com/harusari/chainware/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/auth/service/AuthServiceImpl.java
@@ -73,7 +73,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private Member findMemberByEmail(String email) {
-        return memberQueryRepository.findByEmail(email)
+        return memberQueryRepository.findActiveMemberByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
     }
 

--- a/src/main/java/com/harusari/chainware/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/harusari/chainware/auth/service/CustomUserDetailsService.java
@@ -23,7 +23,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = memberQueryRepository.findByEmail(email)
+        Member member = memberQueryRepository.findActiveMemberByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
 
         Authority authority = authorityCommandRepository.findByAuthorityId(member.getAuthorityId());

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -12,6 +12,7 @@ public class SecurityPolicy {
     };
 
     protected static final String[] MASTER_ONLY_URLS = {
+            "/api/v1/members/email-exists",
             "/api/v1/members/headquarters",
             "/api/v1/members/franchise",
             "/api/v1/members/vendor",

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepository.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepository.java
@@ -3,10 +3,6 @@ package com.harusari.chainware.member.query.repository;
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface MemberQueryRepository extends MemberQueryRepositoryCustom, JpaRepository<Member, Long> {
-
-    Optional<Member> findByEmail(String email);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
@@ -1,7 +1,13 @@
 package com.harusari.chainware.member.query.repository;
 
+import com.harusari.chainware.member.command.domain.aggregate.Member;
+
+import java.util.Optional;
+
 public interface MemberQueryRepositoryCustom {
 
     boolean existsByEmail(String email);
+
+    Optional<Member> findActiveMemberByEmail(String email);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.harusari.chainware.member.query.repository;
 
+import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 import static com.harusari.chainware.member.command.domain.aggregate.QMember.member;
 
@@ -17,11 +20,21 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
         return queryFactory
                 .selectOne()
                 .from(member)
-                .where(
-                        member.email.eq(email),
-                        member.isDeleted.eq(false)
-                )
+                .where(member.email.eq(email))
                 .fetchFirst() != null;
+    }
+
+    @Override
+    public Optional<Member> findActiveMemberByEmail(String email) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(member)
+                        .where(
+                                member.email.eq(email),
+                                member.isDeleted.eq(false)
+                        )
+                        .fetchOne()
+        );
     }
 
 }


### PR DESCRIPTION
Closes #43 

## 🔥 작업 내용  
- 회원 인증 및 조회 로직에서 이메일 중복 확인 쿼리에서 `member.isDeleted.eq(false)` 조건 삭제
- 탈퇴하지 않은 회원을 조회하는`findActiveMemberByEmail()` 추가
- `SecurityPolicy`에서 누락된 `/api/v1/email-exists` 엔드포인트 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #43 
