### PR TITLE
feat: 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityConfig.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import static com.harusari.chainware.config.security.SecurityPolicy.*;
 import static com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType.MASTER;
 
 @Configuration
@@ -41,19 +42,19 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // Master
-                        .requestMatchers(HttpMethod.GET, SecurityPolicy.MASTER_ONLY_URLS).hasAuthority(MASTER.name())
-                        .requestMatchers(HttpMethod.POST, SecurityPolicy.MASTER_ONLY_URLS).hasAuthority(MASTER.name())
-                        .requestMatchers(HttpMethod.PUT, SecurityPolicy.MASTER_ONLY_URLS).hasAuthority(MASTER.name())
-                        .requestMatchers(HttpMethod.DELETE, SecurityPolicy.MASTER_ONLY_URLS).hasAuthority(MASTER.name())
+                        .requestMatchers(HttpMethod.GET, MASTER_ONLY_URLS).hasAuthority(MASTER.name())
+                        .requestMatchers(HttpMethod.POST, MASTER_ONLY_URLS).hasAuthority(MASTER.name())
+                        .requestMatchers(HttpMethod.PUT, MASTER_ONLY_URLS).hasAuthority(MASTER.name())
+                        .requestMatchers(HttpMethod.DELETE, MASTER_ONLY_URLS).hasAuthority(MASTER.name())
 
                         // Public (permitAll)
-                        .requestMatchers(HttpMethod.POST, SecurityPolicy.PUBLIC_URLS).permitAll()
+                        .requestMatchers(HttpMethod.POST, PUBLIC_URLS).permitAll()
 
                         // Authenticated
-                        .requestMatchers(HttpMethod.GET, SecurityPolicy.AUTHENTICATED_URLS).authenticated()
-                        .requestMatchers(HttpMethod.POST, SecurityPolicy.AUTHENTICATED_URLS).authenticated()
-                        .requestMatchers(HttpMethod.PUT, SecurityPolicy.AUTHENTICATED_URLS).authenticated()
-                        .requestMatchers(HttpMethod.DELETE, SecurityPolicy.AUTHENTICATED_URLS).authenticated()
+                        .requestMatchers(HttpMethod.GET, AUTHENTICATED_URLS).authenticated()
+                        .requestMatchers(HttpMethod.POST, AUTHENTICATED_URLS).authenticated()
+                        .requestMatchers(HttpMethod.PUT, AUTHENTICATED_URLS).authenticated()
+                        .requestMatchers(HttpMethod.DELETE, AUTHENTICATED_URLS).authenticated()
 
                         // 그 외 모든 요청 및 HTTP method 차단
                         .anyRequest().denyAll()

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -41,6 +41,7 @@ public class SecurityPolicy {
 
     protected static final String[] AUTHENTICATED_URLS = {
             "/api/v1/auth/logout",
+            "/api/v1/members/password",
             "/api/v1/requisitions/**",
             "/api/v1/orders/**",
             "/api/v1/delivery/**",

--- a/src/main/java/com/harusari/chainware/exception/member/InvalidCurrentPasswordException.java
+++ b/src/main/java/com/harusari/chainware/exception/member/InvalidCurrentPasswordException.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.exception.member;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidCurrentPasswordException extends RuntimeException {
+
+    private final MemberErrorCode errorCode;
+
+    public InvalidCurrentPasswordException(MemberErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/exception/member/InvalidPasswordChangeException.java
+++ b/src/main/java/com/harusari/chainware/exception/member/InvalidPasswordChangeException.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.exception.member;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidPasswordChangeException extends RuntimeException {
+
+    private final MemberErrorCode errorCode;
+
+    public InvalidPasswordChangeException(MemberErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/harusari/chainware/exception/member/MemberErrorCode.java
@@ -10,7 +10,11 @@ public enum MemberErrorCode {
 
     EMAIL_VERIFICATION_REQUIRED("10001", "이메일 중복 확인을 먼저 해주세요.", HttpStatus.BAD_REQUEST),
     EMAIL_ALREADY_EXISTS("10002", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_MEMBER_AUTHORITY("10003", "회원 권한이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+    INVALID_MEMBER_AUTHORITY("10003", "회원 권한이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CURRENT_PASSWORD_EXCEPTION("10004", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PASSWORD_CHANGE_EXCEPTION("10004", "비밀번호는 8자리 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_CONFIRMATION_MISMATCH_EXCEPTION("10005", "변경할 비밀번호와 비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_SAME_AS_CURRENT_EXCEPTION("10006", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/harusari/chainware/exception/member/PasswordConfirmationMismatchException.java
+++ b/src/main/java/com/harusari/chainware/exception/member/PasswordConfirmationMismatchException.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.exception.member;
+
+import lombok.Getter;
+
+@Getter
+public class PasswordConfirmationMismatchException extends RuntimeException {
+
+    private final MemberErrorCode errorCode;
+
+    public PasswordConfirmationMismatchException(MemberErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/exception/member/PasswordSameAsCurrentException.java
+++ b/src/main/java/com/harusari/chainware/exception/member/PasswordSameAsCurrentException.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.exception.member;
+
+import lombok.Getter;
+
+@Getter
+public class PasswordSameAsCurrentException extends RuntimeException {
+
+    private final MemberErrorCode errorCode;
+
+    public PasswordSameAsCurrentException(MemberErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/exception/member/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/harusari/chainware/exception/member/handler/MemberExceptionHandler.java
@@ -1,10 +1,7 @@
 package com.harusari.chainware.exception.member.handler;
 
 import com.harusari.chainware.common.dto.ApiResponse;
-import com.harusari.chainware.exception.member.EmailAlreadyExistsException;
-import com.harusari.chainware.exception.member.EmailVerificationRequiredException;
-import com.harusari.chainware.exception.member.InvalidMemberAuthorityException;
-import com.harusari.chainware.exception.member.MemberErrorCode;
+import com.harusari.chainware.exception.member.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,6 +25,34 @@ public class MemberExceptionHandler {
 
     @ExceptionHandler(InvalidMemberAuthorityException.class)
     public ResponseEntity<ApiResponse<Void>> handleInvalidMemberAuthorityException(InvalidMemberAuthorityException e) {
+        MemberErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(InvalidCurrentPasswordException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidCurrentPasswordException(InvalidCurrentPasswordException e) {
+        MemberErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(InvalidPasswordChangeException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidPasswordChangeException(InvalidPasswordChangeException e) {
+        MemberErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(PasswordConfirmationMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePasswordConfirmationMismatchException(PasswordConfirmationMismatchException e) {
+        MemberErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(PasswordSameAsCurrentException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePasswordSameAsCurrentException(PasswordSameAsCurrentException e) {
         MemberErrorCode errorCode = e.getErrorCode();
         ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
         return new ResponseEntity<>(response, errorCode.getHttpStatus());

--- a/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
@@ -1,7 +1,9 @@
 package com.harusari.chainware.member.command.application.controller;
 
+import com.harusari.chainware.auth.model.CustomUserDetails;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
+import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
@@ -9,6 +11,7 @@ import com.harusari.chainware.member.command.application.service.MemberCommandSe
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -62,6 +65,19 @@ public class MemberCommandController {
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(null));
+    }
+
+    @PutMapping("/members/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @RequestBody PasswordChangeRequest passwordChangeRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        String email = customUserDetails.getEmail();
+        memberCommandService.changePassword(passwordChangeRequest, email);
+
+        return  ResponseEntity
+                .status(HttpStatus.OK)
                 .body(ApiResponse.success(null));
     }
 

--- a/src/main/java/com/harusari/chainware/member/command/application/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.member.command.application.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record PasswordChangeRequest(
+        String currentPassword, String newPassword, String confirmPassword
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
@@ -1,6 +1,7 @@
 package com.harusari.chainware.member.command.application.service;
 
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
+import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
@@ -15,5 +16,7 @@ public interface MemberCommandService {
     void registerVendor(MemberWithVendorRequest memberWithVendorRequest, MultipartFile agreementFile);
 
     void registerWarehouse(MemberWithWarehouseRequest memberWithWarehouseRequest);
+
+    void changePassword(PasswordChangeRequest passwordChangeRequest, String email);
 
 }

--- a/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
@@ -67,6 +67,7 @@ public class Member {
 
     public void updateEncodedPassword(String encodedPassword) {
         this.password = encodedPassword;
+        this.modifiedAt = LocalDateTime.now().withNano(0);
     }
 
     public void updateAuthorityId(Integer authorityId) {

--- a/src/main/java/com/harusari/chainware/member/command/domain/repository/MemberCommandRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/repository/MemberCommandRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.member.command.domain.repository;
+
+import com.harusari.chainware.member.command.domain.aggregate.Member;
+
+public interface MemberCommandRepositoryCustom {
+
+    Member findActiveMemberByEmail(String email);
+
+}

--- a/src/main/java/com/harusari/chainware/member/command/infrastructure/repository/JpaMemberCommandRepository.java
+++ b/src/main/java/com/harusari/chainware/member/command/infrastructure/repository/JpaMemberCommandRepository.java
@@ -2,9 +2,9 @@ package com.harusari.chainware.member.command.infrastructure.repository;
 
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.harusari.chainware.member.command.domain.repository.MemberCommandRepository;
+import com.harusari.chainware.member.command.domain.repository.MemberCommandRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaMemberCommandRepository extends MemberCommandRepository, JpaRepository<Member, Long> {
-
+public interface JpaMemberCommandRepository extends MemberCommandRepository, MemberCommandRepositoryCustom, JpaRepository<Member, Long> {
 
 }

--- a/src/main/java/com/harusari/chainware/member/command/infrastructure/repository/MemberCommandRepositoryCustomImpl.java
+++ b/src/main/java/com/harusari/chainware/member/command/infrastructure/repository/MemberCommandRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package com.harusari.chainware.member.command.infrastructure.repository;
+
+import com.harusari.chainware.member.command.domain.aggregate.Member;
+import com.harusari.chainware.member.command.domain.repository.MemberCommandRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.harusari.chainware.member.command.domain.aggregate.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberCommandRepositoryCustomImpl implements MemberCommandRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Member findActiveMemberByEmail(String email) {
+        return queryFactory
+                .selectFrom(member)
+                .where(
+                        member.email.eq(email),
+                        member.isDeleted.eq(false)
+                )
+                .fetchOne();
+    }
+
+}


### PR DESCRIPTION
Closes #45 

## 🔥 작업 내용  
- 비밀번호를 변경할 때 현재 비밀번호가 일치하는지 검증하는 기능 구현
- 변경할 비밀번호가 8자리 이상인지 검증하는 기능 구현
- 변경할 비밀번호와 변경할 비밀번호 확인 값이 서로 같은지 검증하는 기능 구현
- 현재 비밀번호와 변경할 비밀번호가 같으면 예외를 발생시키는 기능 구현
- 데이터베이스에 변경할 비밀번호로 업데이트하는 기능 구현
- `SecurityPolicy`에 비밀번호 엔드포인트 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #45 
