### PR TITLE
feat: 회원 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/common/dto/PageResponse.java
+++ b/src/main/java/com/harusari/chainware/common/dto/PageResponse.java
@@ -1,0 +1,17 @@
+package com.harusari.chainware.common.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> contents, int page, int size,
+        int totalPages, long totalElements
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(), page.getNumber(), page.getSize(),
+                page.getTotalPages(), page.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -16,7 +16,8 @@ public class SecurityPolicy {
             "/api/v1/members/headquarters",
             "/api/v1/members/franchise",
             "/api/v1/members/vendor",
-            "/api/v1/members/warehouse"
+            "/api/v1/members/warehouse",
+            "/api/v1/members"
     };
 
     protected static final String[] GENERAL_MANAGER_URLS = {

--- a/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
@@ -1,15 +1,18 @@
 package com.harusari.chainware.member.query.controller;
 
 import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
+import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.harusari.chainware.member.query.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -27,6 +30,19 @@ public class MemberQueryController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(emailExistsResponse));
+    }
+
+    @GetMapping("/members")
+    public ResponseEntity<ApiResponse<PageResponse<MemberSearchResponse>>> searchMembers(
+            @ModelAttribute MemberSearchRequest memberSearchRequest,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<MemberSearchResponse> members = memberQueryService.searchMembers(memberSearchRequest, pageable);
+        PageResponse<MemberSearchResponse> pageResponse = PageResponse.from(members);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(pageResponse));
     }
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/dto/request/MemberSearchRequest.java
+++ b/src/main/java/com/harusari/chainware/member/query/dto/request/MemberSearchRequest.java
@@ -1,0 +1,13 @@
+package com.harusari.chainware.member.query.dto.request;
+
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MemberSearchRequest(
+        String email, MemberAuthorityType authorityName, String position,
+        LocalDate joinDateFrom, LocalDate joinDateTo, Boolean isDeleted
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/query/dto/response/MemberSearchResponse.java
+++ b/src/main/java/com/harusari/chainware/member/query/dto/response/MemberSearchResponse.java
@@ -1,0 +1,13 @@
+package com.harusari.chainware.member.query.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record MemberSearchResponse(
+        String email, String name, String authorityLabelKr, String phoneNumber,
+        LocalDate birthDate, String position, LocalDateTime joinAt, boolean isDeleted
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
@@ -1,6 +1,10 @@
 package com.harusari.chainware.member.query.repository;
 
 import com.harusari.chainware.member.command.domain.aggregate.Member;
+import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -9,5 +13,7 @@ public interface MemberQueryRepositoryCustom {
     boolean existsByEmail(String email);
 
     Optional<Member> findActiveMemberByEmail(String email);
+
+    Page<MemberSearchResponse> findMembers(MemberSearchRequest condition, Pageable pageable);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
@@ -1,12 +1,24 @@
 package com.harusari.chainware.member.query.repository;
 
 import com.harusari.chainware.member.command.domain.aggregate.Member;
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
+import static com.harusari.chainware.member.command.domain.aggregate.QAuthority.authority;
 import static com.harusari.chainware.member.command.domain.aggregate.QMember.member;
 
 @Repository
@@ -35,6 +47,68 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
                         )
                         .fetchOne()
         );
+    }
+
+    @Override
+    public Page<MemberSearchResponse> findMembers(MemberSearchRequest memberSearchRequest, Pageable pageable) {
+        List<MemberSearchResponse> contents = queryFactory
+                .select(Projections.constructor(MemberSearchResponse.class,
+                        member.email, member.name, authority.authorityLabelKr,
+                        member.phoneNumber, member.birthDate, member.position,
+                        member.joinAt, member.isDeleted
+                ))
+                .from(member)
+                .leftJoin(authority).on(member.authorityId.eq(authority.authorityId))
+                .where(
+                        emailEq(memberSearchRequest.email()),
+                        authorityEq(memberSearchRequest.authorityName()),
+                        joinDateBetween(memberSearchRequest.joinDateFrom(), memberSearchRequest.joinDateTo()),
+                        isDeletedFalse(memberSearchRequest.isDeleted())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(member.memberId.asc())
+                .fetch();
+
+        Long result = queryFactory
+                .select(member.count())
+                .from(member)
+                .leftJoin(authority).on(member.authorityId.eq(authority.authorityId))
+                .where(
+                        emailEq(memberSearchRequest.email()),
+                        authorityEq(memberSearchRequest.authorityName()),
+                        joinDateBetween(memberSearchRequest.joinDateFrom(), memberSearchRequest.joinDateTo())
+                )
+                .fetchOne();
+
+        final long TOTAL_DEFAULT_VALUE = 0L;
+        long total = Optional.ofNullable(result).orElse(TOTAL_DEFAULT_VALUE);
+
+        return new PageImpl<>(contents, pageable, total);
+    }
+
+    private BooleanExpression emailEq(String email) {
+        return email != null ? member.email.eq(email) : null;
+    }
+
+    private BooleanExpression authorityEq(MemberAuthorityType authorityName) {
+        return authorityName != null ? authority.authorityName.eq(authorityName) : null;
+    }
+
+    private BooleanExpression joinDateBetween(LocalDate from, LocalDate to) {
+        if (from != null && to != null) {
+            return member.joinAt.between(from.atStartOfDay(), to.atTime(LocalTime.MAX));
+        } else if (from != null) {
+            return member.joinAt.goe(from.atStartOfDay());
+        } else if (to != null) {
+            return member.joinAt.loe(to.atTime(LocalTime.MAX));
+        } else {
+            return null;
+        }
+    }
+
+    private BooleanExpression isDeletedFalse(boolean isDeleted) {
+        return !isDeleted ? member.isDeleted.eq(false) : member.isDeleted.eq(true);
     }
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
@@ -1,9 +1,15 @@
 package com.harusari.chainware.member.query.service;
 
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
+import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface MemberQueryService {
 
     EmailExistsResponse checkEmailDuplicate(String email);
+
+    Page<MemberSearchResponse> searchMembers(MemberSearchRequest memberSearchRequest, Pageable pageable);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
@@ -1,8 +1,12 @@
 package com.harusari.chainware.member.query.service;
 
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
+import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.harusari.chainware.member.query.repository.MemberQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +39,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 .exists(false)
                 .validationToken(token)
                 .build();
+    }
+
+    @Override
+    public Page<MemberSearchResponse> searchMembers(MemberSearchRequest memberSearchRequest, Pageable pageable) {
+        return memberQueryRepository.findMembers(memberSearchRequest, pageable);
     }
 
     private String generateAndStoreEmailValidationToken(String email) {


### PR DESCRIPTION
Closes #47 

## 🔥 작업 내용  
- 마스터 권한만 접근 가능한 회원 프로필 조회 API를 구현
- 페이징 기능을 적용하여 한 페이지당 10개의 회원 프로필을 조회할 수 있도록 구현
- 다음 검색 조건을 옵션으로 적용할 수 있도록 구현
  - 이메일, 이름, 전화번호, 생년월일, 권한, 직책, 탈퇴여부
  - 가입일시 (아래 검색 방식 지원)
    - 특정 날짜 단일 선택 검색
    - 날짜 범위 검색 (from ~ to)
- 정렬 조건은 항상 member_id를 기준으로 오름차순 정렬

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #47 
