### PR TITLE
feat: 재고에 대한 주문의 동시성 제어 추가 및 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.25.2'
 
 	// aws sdk s3 v2
 	implementation 'software.amazon.awssdk:s3:2.25.57'

--- a/src/main/java/com/harusari/chainware/auth/model/CustomUserDetails.java
+++ b/src/main/java/com/harusari/chainware/auth/model/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.auth.model;
 
+import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,12 @@ public class CustomUserDetails implements UserDetails {
     private final Long memberId;
     private final String email;
     private final MemberAuthorityType memberAuthorityType;
+
+    public CustomUserDetails(Member member) {
+        this.memberId = member.getMemberId();
+        this.email = member.getEmail();
+        this.memberAuthorityType = MemberAuthorityType.of(member.getAuthorityId()); // ← 이 부분이 핵심
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/harusari/chainware/config/RedisConfig.java
+++ b/src/main/java/com/harusari/chainware/config/RedisConfig.java
@@ -57,8 +57,7 @@ public class RedisConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://" + redisHost + ":" + redisPort)
-                .setPassword(redisPassword);
+                .setAddress("redis://" + redisHost + ":" + redisPort);
         return Redisson.create(config);
     }
 

--- a/src/main/java/com/harusari/chainware/config/RedisConfig.java
+++ b/src/main/java/com/harusari/chainware/config/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.harusari.chainware.config;
 
 import com.harusari.chainware.auth.dto.RefreshTokenDTO;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +51,15 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new Jackson2JsonRedisSerializer<>(RefreshTokenDTO.class));
         return template;
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisHost + ":" + redisPort)
+                .setPassword(redisPassword);
+        return Redisson.create(config);
     }
 
 }

--- a/src/main/java/com/harusari/chainware/config/security/SecurityConfig.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static com.harusari.chainware.config.security.SecurityPolicy.*;
-import static com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType.MASTER;
+import static com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType.*;
 
 @Configuration
 @EnableWebSecurity
@@ -46,6 +46,15 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, MASTER_ONLY_URLS).hasAuthority(MASTER.name())
                         .requestMatchers(HttpMethod.PUT, MASTER_ONLY_URLS).hasAuthority(MASTER.name())
                         .requestMatchers(HttpMethod.DELETE, MASTER_ONLY_URLS).hasAuthority(MASTER.name())
+
+                        // GENERAL_MANAGER
+                        .requestMatchers(GENERAL_MANAGER_URLS).hasAuthority(GENERAL_MANAGER.name())
+
+                        // SENIOR_MANAGER
+                        .requestMatchers(SENIOR_MANAGER_URLS).hasAuthority(SENIOR_MANAGER.name())
+
+                        // FRANCHISE_MANAGER
+                        .requestMatchers(FRANCHISE_MANAGER_URLS).hasAuthority(FRANCHISE_MANAGER.name())
 
                         // Public (permitAll)
                         .requestMatchers(HttpMethod.POST, PUBLIC_URLS).permitAll()

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -20,11 +20,13 @@ public class SecurityPolicy {
     };
 
     protected static final String[] GENERAL_MANAGER_URLS = {
-
+            "/api/v1/orders/{orderId}/approve",
+            "/api/v1/orders/{orderId}/reject"
     };
 
     protected static final String[] SENIOR_MANAGER_URLS = {
-
+            "/api/v1/orders/{orderId}/approve",
+            "/api/v1/orders/{orderId}/reject"
     };
 
     protected static final String[] WAREHOUSE_MANAGER_URLS = {
@@ -32,7 +34,9 @@ public class SecurityPolicy {
     };
 
     protected static final String[] FRANCHISE_MANAGER_URLS = {
-
+            "/api/v1/orders",
+            "/api/v1/orders/{orderId}",
+            "/api/v1/orders/{orderId}/cancel"
     };
 
     protected static final String[] VENDOR_MANAGER_URLS = {
@@ -43,7 +47,6 @@ public class SecurityPolicy {
             "/api/v1/auth/logout",
             "/api/v1/members/password",
             "/api/v1/requisitions/**",
-            "/api/v1/orders/**",
             "/api/v1/delivery/**",
             "/api/v1/warehouse/**",
     };

--- a/src/main/java/com/harusari/chainware/member/command/domain/aggregate/MemberAuthorityType.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/aggregate/MemberAuthorityType.java
@@ -17,4 +17,17 @@ public enum MemberAuthorityType {
 
     private final String authorityLabelKo;
 
+    public static MemberAuthorityType of(Integer authorityId) {
+        return switch (authorityId) {
+            case 1 -> MASTER;
+            case 2 -> GENERAL_MANAGER;
+            case 3 -> SENIOR_MANAGER;
+            case 4 -> WAREHOUSE_MANAGER;
+            case 5 -> FRANCHISE_MANAGER;
+            case 6 -> VENDOR_MANAGER;
+            case 99 -> SYSTEM;
+            default -> throw new IllegalArgumentException("Unknown authorityId: " + authorityId);
+        };
+    }
+
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/controller/OrderCommandController.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.order.command.application.controller;
 
+import com.harusari.chainware.auth.model.CustomUserDetails;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.order.command.application.dto.request.OrderCreateRequest;
 import com.harusari.chainware.order.command.application.dto.request.OrderRejectRequest;
@@ -8,60 +9,65 @@ import com.harusari.chainware.order.command.application.dto.response.OrderComman
 import com.harusari.chainware.order.command.application.service.OrderCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
 public class OrderCommandController {
 
     private final OrderCommandService orderCommandService;
 
     // 주문 등록
-    @PostMapping("/orders")
+    @PostMapping
     public ResponseEntity<ApiResponse<OrderCommandResponse>> createOrder(
-            @RequestBody OrderCreateRequest request
+            @RequestBody OrderCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        System.out.println("createOrder 메소드 실행");
-        OrderCommandResponse response = orderCommandService.createOrder(request);
+        OrderCommandResponse response = orderCommandService.createOrder(request, customUserDetails.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 주문 수정
-    @PutMapping("/orders/{orderId}")
+    @PutMapping("/{orderId}")
     public ResponseEntity<ApiResponse<OrderCommandResponse>> updateOrder(
             @PathVariable Long orderId,
-            @RequestBody OrderUpdateRequest request
+            @RequestBody OrderUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        OrderCommandResponse response = orderCommandService.updateOrder(orderId, request);
+        OrderCommandResponse response = orderCommandService.updateOrder(orderId, request, customUserDetails.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 주문 취소
-    @PutMapping("/orders/{orderId}/cancel")
+    @PutMapping("/{orderId}/cancel")
     public ResponseEntity<ApiResponse<OrderCommandResponse>> cancelOrder(
-            @PathVariable Long orderId
+            @PathVariable Long orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        OrderCommandResponse response = orderCommandService.cancelOrder(orderId);
+        OrderCommandResponse response = orderCommandService.cancelOrder(orderId, customUserDetails.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 주문 승인
-    @PutMapping("/orders/{orderId}/approve")
+    @PutMapping("/{orderId}/approve")
     public ResponseEntity<ApiResponse<OrderCommandResponse>> approveOrder(
-            @PathVariable Long orderId
+            @PathVariable Long orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        OrderCommandResponse response = orderCommandService.approveOrder(orderId);
+        OrderCommandResponse response = orderCommandService.approveOrder(orderId, customUserDetails.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 주문 반려
-    @PutMapping("/orders/{orderId}/reject")
+    @PutMapping("/{orderId}/reject")
     public ResponseEntity<ApiResponse<OrderCommandResponse>> rejectOrder(
             @PathVariable Long orderId,
-            @RequestBody OrderRejectRequest request
+            @RequestBody OrderRejectRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        OrderCommandResponse response = orderCommandService.rejectOrder(orderId, request);
+        OrderCommandResponse response = orderCommandService.rejectOrder(orderId, request, customUserDetails.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderCreateRequest.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@Builder
 public class OrderCreateRequest {
     private Long franchiseId;
     private Long memberId;

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailCreateRequest.java
@@ -1,8 +1,10 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class OrderDetailCreateRequest {
     private Long productId;
     private Integer quantity;

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailUpdateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderDetailUpdateRequest.java
@@ -1,8 +1,10 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class OrderDetailUpdateRequest {
     private Long productId;
     private Integer quantity;

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderRejectRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderRejectRequest.java
@@ -1,8 +1,14 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class OrderRejectRequest {
     private String rejectReason;
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderUpdateRequest.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/dto/request/OrderUpdateRequest.java
@@ -1,10 +1,14 @@
 package com.harusari.chainware.order.command.application.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@Builder
 public class OrderUpdateRequest {
+    private LocalDate deliveryDueDate;
     private List<OrderDetailUpdateRequest> orderDetails;
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandService.java
@@ -7,14 +7,10 @@ import com.harusari.chainware.order.command.application.dto.response.OrderComman
 
 public interface OrderCommandService {
 
-    OrderCommandResponse createOrder(OrderCreateRequest request);
-
-    OrderCommandResponse updateOrder(Long orderId, OrderUpdateRequest request);
-
-    OrderCommandResponse cancelOrder(Long orderId);
-
-    OrderCommandResponse approveOrder(Long orderId);
-
-    OrderCommandResponse rejectOrder(Long orderId, OrderRejectRequest request);
+    OrderCommandResponse createOrder(OrderCreateRequest request, Long memberId);
+    OrderCommandResponse updateOrder(Long orderId, OrderUpdateRequest request, Long memberId);
+    OrderCommandResponse cancelOrder(Long orderId, Long memberId);
+    OrderCommandResponse approveOrder(Long orderId, Long memberId);
+    OrderCommandResponse rejectOrder(Long orderId, OrderRejectRequest request, Long memberId);
 
 }

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
@@ -206,7 +206,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 productCount,
                 totalQuantity,
                 totalPrice,
-                LocalDateTime.now()
+                request.getDeliveryDueDate()
         );
 
         // 6. 저장

--- a/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImpl.java
@@ -4,10 +4,6 @@ import com.harusari.chainware.delivery.command.domain.aggregate.Delivery;
 import com.harusari.chainware.delivery.command.domain.aggregate.DeliveryMethod;
 import com.harusari.chainware.delivery.command.domain.aggregate.DeliveryStatus;
 import com.harusari.chainware.delivery.command.domain.repository.DeliveryRepository;
-import com.harusari.chainware.member.command.domain.aggregate.Member;
-import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
-import com.harusari.chainware.member.command.domain.repository.AuthorityCommandRepository;
-import com.harusari.chainware.member.command.domain.repository.MemberCommandRepository;
 import com.harusari.chainware.member.command.infrastructure.repository.JpaAuthorityCommandRepository;
 import com.harusari.chainware.member.command.infrastructure.repository.JpaMemberCommandRepository;
 import com.harusari.chainware.order.command.application.dto.request.*;
@@ -29,7 +25,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 
 

--- a/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/harusari/chainware/order/command/domain/aggregate/Order.java
@@ -42,7 +42,6 @@ public class Order {
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
-
     @Column(name = "reject_reason")
     private String rejectReason;
 
@@ -68,11 +67,12 @@ public class Order {
         this.createdAt = createdAt;
     }
 
-    public void update(int productCount, int totalQuantity, long totalPrice, LocalDateTime modifiedAt) {
+    public void update(int productCount, int totalQuantity, long totalPrice, LocalDate deliveryDueDate) {
         this.productCount = productCount;
         this.totalQuantity = totalQuantity;
         this.totalPrice = totalPrice;
-        this.modifiedAt = modifiedAt;
+        this.deliveryDueDate = deliveryDueDate;
+        this.modifiedAt = LocalDateTime.now();
     }
 
     public void changeStatus(OrderStatus status, String rejectReason, LocalDateTime modifiedAt) {

--- a/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
@@ -17,6 +17,8 @@ public enum OrderErrorCode {
     REJECT_REASON_REQUIRED("10002", "반려 사유가 필요합니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_INVENTORY_NOT_FOUND("10003", "창고에 보유 재고가 없는 제품입니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_AVAILABLE_QUANTITY("10004", "주문 가능 재고를 초과하는 주문은 불가능합니다.", HttpStatus.BAD_REQUEST),
+    MEMBER_NOT_FOUND("10005", "존재하지 않는 사용자입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED_ORDER_ACCESS("10006", "조작이 불가능한 권한의 사용자입니다.", HttpStatus.BAD_REQUEST),
     METHOD_ARG_NOT_VALID("10999", "@Valid 검증 오류입니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;

--- a/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/harusari/chainware/order/exception/OrderErrorCode.java
@@ -13,13 +13,19 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public enum OrderErrorCode {
 
-    ORDER_UPDATE_INVALID("10001", "수정 가능한 상태가 아닙니다.", HttpStatus.BAD_REQUEST),
-    REJECT_REASON_REQUIRED("10002", "반려 사유가 필요합니다.", HttpStatus.BAD_REQUEST),
-    PRODUCT_INVENTORY_NOT_FOUND("10003", "창고에 보유 재고가 없는 제품입니다.", HttpStatus.BAD_REQUEST),
-    INSUFFICIENT_AVAILABLE_QUANTITY("10004", "주문 가능 재고를 초과하는 주문은 불가능합니다.", HttpStatus.BAD_REQUEST),
-    MEMBER_NOT_FOUND("10005", "존재하지 않는 사용자입니다.", HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED_ORDER_ACCESS("10006", "조작이 불가능한 권한의 사용자입니다.", HttpStatus.BAD_REQUEST),
-    METHOD_ARG_NOT_VALID("10999", "@Valid 검증 오류입니다.", HttpStatus.BAD_REQUEST);
+    INVENTORY_LOCK_TIMEOUT("10001", "재고 확인 중 락 획득에 실패했습니다.", HttpStatus.CONFLICT),
+    EMPTY_ORDER_DETAIL("10002", "주문 상세 항목이 비어 있습니다.", HttpStatus.BAD_REQUEST),
+    PRODUCT_INVENTORY_NOT_FOUND("10003", "해당 제품의 창고 재고를 찾을 수 없습니.다.", HttpStatus.BAD_REQUEST),
+    INVALID_ORDER_QUANTITY("10004", "주문 수량은 1 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_AVAILABLE_QUANTITY("10005", "가용 재고를 초과하는 수량은 주문할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ORDER_SAVE_FAILED("10006", "주문 저장 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ORDER_NOT_FOUND("10007", "주문 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CANNOT_UPDATE_ORDER_STATUS("10008", "해당 주문은 현재 상태에서는 수정할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_CANCEL_ORDER("10009", "해당 주문은 현재 상태에서는 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_APPROVE_ORDER("10010", "해당 주문은 현재 상태에서는 승인할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_REJECT_ORDER("10011", "해당 주문은 현재 상태에서는 반려할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED_ORDER_ACCESS("10012", "해당 주문에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    REJECT_REASON_REQUIRED("10013", "반려 사유를 입력해야 합니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/harusari/chainware/order/exception/OrderException.java
+++ b/src/main/java/com/harusari/chainware/order/exception/OrderException.java
@@ -3,11 +3,11 @@ package com.harusari.chainware.order.exception;
 import lombok.Getter;
 
 @Getter
-public class OrderUpdateInvalidException extends RuntimeException {
+public class OrderException extends RuntimeException {
 
     private final OrderErrorCode errorCode;
 
-    public OrderUpdateInvalidException(OrderErrorCode errorCode) {
+    public OrderException(OrderErrorCode errorCode) {
         super(errorCode.getErrorMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/harusari/chainware/order/exception/handler/OrderExceptionHandler.java
+++ b/src/main/java/com/harusari/chainware/order/exception/handler/OrderExceptionHandler.java
@@ -2,7 +2,7 @@ package com.harusari.chainware.order.exception.handler;
 
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.order.exception.OrderErrorCode;
-import com.harusari.chainware.order.exception.OrderUpdateInvalidException;
+import com.harusari.chainware.order.exception.OrderException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class OrderExceptionHandler {
 
-    @ExceptionHandler(OrderUpdateInvalidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleUpdateInvalidException(OrderUpdateInvalidException e) {
+    @ExceptionHandler(OrderException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUpdateInvalidException(OrderException e) {
         OrderErrorCode errorCode = e.getErrorCode();
         ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
         return new ResponseEntity<>(response, errorCode.getHttpStatus());

--- a/src/main/java/com/harusari/chainware/warehouse/command/infrastructure/repository/JpaWarehouseInventoryRepository.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/infrastructure/repository/JpaWarehouseInventoryRepository.java
@@ -1,9 +1,19 @@
 package com.harusari.chainware.warehouse.command.infrastructure.repository;
-
 import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseInventory;
 import com.harusari.chainware.warehouse.command.domain.repository.WarehouseInventoryRepository;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface JpaWarehouseInventoryRepository extends WarehouseInventoryRepository, JpaRepository<WarehouseInventory, Long> {
+
+    // 비관적 락을 이용한 창고 재고 수량 검증
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT w FROM WarehouseInventory w WHERE w.productId = :productId")
+    Optional<WarehouseInventory> findByProductIdForUpdate(@Param("productId") Long productId);
 
 }

--- a/src/test/java/com/harusari/chainware/order/command/application/controller/OrderCommandControllerTest.java
+++ b/src/test/java/com/harusari/chainware/order/command/application/controller/OrderCommandControllerTest.java
@@ -1,0 +1,395 @@
+package com.harusari.chainware.order.command.application.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.harusari.chainware.order.command.application.dto.request.*;
+import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
+import com.harusari.chainware.order.command.application.service.OrderCommandService;
+import com.harusari.chainware.order.command.domain.aggregate.OrderStatus;
+import com.harusari.chainware.order.exception.OrderErrorCode;
+import com.harusari.chainware.order.exception.OrderException;
+import com.harusari.chainware.order.exception.handler.OrderExceptionHandler;
+import com.harusari.chainware.securitysupport.WithMockCustomUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(OrderCommandController.class)
+@Import(OrderExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[주문 - controller] OrderCommandController 테스트")
+class OrderCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OrderCommandService orderCommandService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    OrderCreateRequest validRequest;
+    OrderCommandResponse response;
+
+    @BeforeEach
+    void setUp() {
+        validRequest = OrderCreateRequest.builder()
+                .franchiseId(1L)
+                .deliveryDueDate(LocalDate.now().plusDays(3))
+                .orderDetails(List.of(
+                        OrderDetailCreateRequest.builder()
+                                .productId(1L)
+                                .quantity(3)
+                                .build(),
+                        OrderDetailCreateRequest.builder()
+                                .productId(2L)
+                                .quantity(2)
+                                .build()
+                ))
+                .build();
+
+        response = OrderCommandResponse.builder()
+                .orderId(1L)
+                .franchiseId(1L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("[주문 등록] 성공 테스트")
+    @WithMockCustomUser(memberId = 100L, position = "FRANCHISE_MANAGER")
+    void testCreateOrderSuccess() throws Exception {
+        // when
+        when(orderCommandService.createOrder(any(), eq(100L))).thenReturn(response);
+
+        // then
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderId").value(response.getOrderId()))
+                .andExpect(jsonPath("$.data.franchiseId").value(response.getFranchiseId()));
+    }
+
+    @Test
+    @DisplayName("[주문 등록] 재고 락 획득 실패 예외 테스트")
+    @WithMockCustomUser(memberId = 100L, position = "FRANCHISE_MANAGER")
+    void testCreateOrder_LockFail() throws Exception {
+        // when
+        when(orderCommandService.createOrder(any(), anyLong()))
+                .thenThrow(new OrderException(OrderErrorCode.INVENTORY_LOCK_TIMEOUT));
+
+        // then
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(OrderErrorCode.INVENTORY_LOCK_TIMEOUT.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("[주문 등록] 빈 주문 상세 예외 테스트")
+    @WithMockCustomUser(memberId = 100L, position = "FRANCHISE_MANAGER")
+    void testCreateOrder_EmptyDetails() throws Exception {
+        // given
+        OrderCreateRequest requestWithEmptyDetails = OrderCreateRequest.builder()
+                .franchiseId(validRequest.getFranchiseId())
+                .deliveryDueDate(validRequest.getDeliveryDueDate())
+                .orderDetails(List.of())  // 빈 리스트 전달
+                .build();
+
+        // when
+        when(orderCommandService.createOrder(any(), anyLong()))
+                .thenThrow(new OrderException(OrderErrorCode.EMPTY_ORDER_DETAIL));
+
+        // then
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestWithEmptyDetails)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(OrderErrorCode.EMPTY_ORDER_DETAIL.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("[주문 수정] 성공 테스트")
+    @WithMockCustomUser(memberId = 100L, position = "FRANCHISE_MANAGER")
+    void testUpdateOrderSuccess() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderUpdateRequest updateRequest = OrderUpdateRequest.builder()
+                .deliveryDueDate(LocalDate.now().plusDays(5))
+                .orderDetails(List.of(
+                        OrderDetailUpdateRequest.builder()
+                                .productId(1L)
+                                .quantity(5)
+                                .build(),
+                        OrderDetailUpdateRequest.builder()
+                                .productId(2L)
+                                .quantity(1)
+                                .build()
+                ))
+                .build();
+
+        OrderCommandResponse updatedResponse = OrderCommandResponse.builder()
+                .orderId(orderId)
+                .franchiseId(1L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // when
+        when(orderCommandService.updateOrder(eq(orderId), any(OrderUpdateRequest.class), eq(100L)))
+                .thenReturn(updatedResponse);
+
+        // then
+        mockMvc.perform(put("/api/v1/orders/{orderId}", orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderId").value(orderId));
+    }
+
+    @Test
+    @DisplayName("[주문 수정] 수정 불가 상태 예외 테스트")
+    @WithMockCustomUser(memberId = 100L, position = "FRANCHISE_MANAGER")
+    void testUpdateOrder_CannotUpdateStatus() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderUpdateRequest updateRequest = OrderUpdateRequest.builder()
+                .deliveryDueDate(LocalDate.now().plusDays(5))
+                .orderDetails(List.of(
+                        OrderDetailUpdateRequest.builder()
+                                .productId(1L)
+                                .quantity(3)
+                                .build()
+                ))
+                .build();
+
+        // when
+        when(orderCommandService.updateOrder(eq(orderId), any(OrderUpdateRequest.class), eq(100L)))
+                .thenThrow(new OrderException(OrderErrorCode.CANNOT_UPDATE_ORDER_STATUS));
+
+        // then
+        mockMvc.perform(put("/api/v1/orders/{orderId}", orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(OrderErrorCode.CANNOT_UPDATE_ORDER_STATUS.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("[주문 취소] 성공 테스트")
+    @WithMockCustomUser(memberId = 100L, position = "FRANCHISE_MANAGER")
+    void testCancelOrderSuccess() throws Exception {
+        // given
+        Long orderId = 1L;
+
+        OrderCommandResponse cancelResponse = OrderCommandResponse.builder()
+                .orderId(orderId)
+                .franchiseId(1L)
+                .orderStatus(OrderStatus.CANCELLED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // when
+        when(orderCommandService.cancelOrder(eq(orderId), eq(100L)))
+                .thenReturn(cancelResponse);
+
+        // then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/cancel", orderId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderId").value(orderId))
+                .andExpect(jsonPath("$.data.orderStatus").value("CANCELLED"));
+    }
+
+    @Test
+    @DisplayName("[주문 취소] 취소 불가 상태 예외 테스트")
+    @WithMockCustomUser(memberId = 100L, position = "FRANCHISE_MANAGER")
+    void testCancelOrder_CannotCancelStatus() throws Exception {
+        // given
+        Long orderId = 1L;
+
+        // when
+        when(orderCommandService.cancelOrder(eq(orderId), eq(100L)))
+                .thenThrow(new OrderException(OrderErrorCode.CANNOT_CANCEL_ORDER));
+
+        // then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/cancel", orderId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(OrderErrorCode.CANNOT_CANCEL_ORDER.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("[주문 승인] 성공 테스트 - 일반 관리자")
+    @WithMockCustomUser(memberId = 200L, position = "GENERAL_MANAGER")
+    void testApproveOrderSuccessAsGeneralManager() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderCommandResponse approveResponse = OrderCommandResponse.builder()
+                .orderId(orderId)
+                .franchiseId(1L)
+                .orderStatus(OrderStatus.APPROVED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // when
+        when(orderCommandService.approveOrder(eq(orderId), eq(200L)))
+                .thenReturn(approveResponse);
+
+        // then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/approve", orderId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderId").value(orderId))
+                .andExpect(jsonPath("$.data.orderStatus").value("APPROVED"));
+    }
+
+    @Test
+    @DisplayName("[주문 승인] 성공 테스트 - 책임 관리자")
+    @WithMockCustomUser(memberId = 300L, position = "SENIOR_MANAGER")
+    void testApproveOrderSuccessAsSeniorManager() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderCommandResponse approveResponse = OrderCommandResponse.builder()
+                .orderId(orderId)
+                .franchiseId(1L)
+                .orderStatus(OrderStatus.APPROVED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // when
+        when(orderCommandService.approveOrder(eq(orderId), eq(300L)))
+                .thenReturn(approveResponse);
+
+        // then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/approve", orderId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderStatus").value("APPROVED"));
+    }
+
+    @Test
+    @DisplayName("[주문 승인] 승인 불가 상태 예외 테스트")
+    @WithMockCustomUser(memberId = 200L, position = "GENERAL_MANAGER")
+    void testApproveOrder_CannotApprove() throws Exception {
+        // given
+        Long orderId = 1L;
+
+        // when
+        when(orderCommandService.approveOrder(eq(orderId), eq(200L)))
+                .thenThrow(new OrderException(OrderErrorCode.CANNOT_APPROVE_ORDER));
+
+        // then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/approve", orderId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(OrderErrorCode.CANNOT_APPROVE_ORDER.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("[주문 반려] 성공 테스트")
+    @WithMockCustomUser(memberId = 200L, position = "GENERAL_MANAGER")
+    void testRejectOrderSuccess() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderRejectRequest rejectRequest = OrderRejectRequest.builder()
+                .rejectReason("요청 수량 오류")
+                .build();
+
+        OrderCommandResponse rejectResponse = OrderCommandResponse.builder()
+                .orderId(orderId)
+                .franchiseId(1L)
+                .orderStatus(OrderStatus.REJECTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(orderCommandService.rejectOrder(eq(orderId), any(OrderRejectRequest.class), eq(200L)))
+                .thenReturn(rejectResponse);
+
+        // when & then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/reject", orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rejectRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderStatus").value("REJECTED"));
+    }
+
+    @Test
+    @DisplayName("[주문 반려] 반려 사유 누락 예외 테스트")
+    @WithMockCustomUser(memberId = 200L, position = "GENERAL_MANAGER")
+    void testRejectOrder_MissingReason() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderRejectRequest rejectRequest = OrderRejectRequest.builder()
+                .rejectReason("  ")  // 빈 값 처리
+                .build();
+
+        when(orderCommandService.rejectOrder(eq(orderId), any(OrderRejectRequest.class), eq(200L)))
+                .thenThrow(new OrderException(OrderErrorCode.REJECT_REASON_REQUIRED));
+
+        // when & then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/reject", orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rejectRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(OrderErrorCode.REJECT_REASON_REQUIRED.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("[주문 반려] 반려 불가 상태 예외 테스트")
+    @WithMockCustomUser(memberId = 200L, position = "GENERAL_MANAGER")
+    void testRejectOrder_InvalidStatus() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderRejectRequest rejectRequest = OrderRejectRequest.builder()
+                .rejectReason("사유 있음")
+                .build();
+
+        when(orderCommandService.rejectOrder(eq(orderId), any(OrderRejectRequest.class), eq(200L)))
+                .thenThrow(new OrderException(OrderErrorCode.CANNOT_REJECT_ORDER));
+
+        // when & then
+        mockMvc.perform(put("/api/v1/orders/{orderId}/reject", orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rejectRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(OrderErrorCode.CANNOT_REJECT_ORDER.getErrorCode()));
+    }
+
+}
+

--- a/src/test/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImplTest.java
+++ b/src/test/java/com/harusari/chainware/order/command/application/service/OrderCommandServiceImplTest.java
@@ -1,0 +1,529 @@
+package com.harusari.chainware.order.command.application.service;
+
+import com.harusari.chainware.delivery.command.domain.aggregate.Delivery;
+import com.harusari.chainware.delivery.command.domain.repository.DeliveryRepository;
+import com.harusari.chainware.order.command.application.dto.request.*;
+import com.harusari.chainware.order.command.application.dto.response.OrderCommandResponse;
+import com.harusari.chainware.order.command.domain.aggregate.Order;
+import com.harusari.chainware.order.command.domain.aggregate.OrderDetail;
+import com.harusari.chainware.order.command.domain.aggregate.OrderStatus;
+import com.harusari.chainware.order.command.domain.repository.OrderDetailRepository;
+import com.harusari.chainware.order.command.domain.repository.OrderRepository;
+import com.harusari.chainware.order.exception.OrderErrorCode;
+import com.harusari.chainware.order.exception.OrderException;
+import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseInventory;
+import com.harusari.chainware.warehouse.command.infrastructure.repository.JpaWarehouseInventoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[주문 - service] OrderCommandServiceImpl 테스트")
+class OrderCommandServiceImplTest {
+
+    @InjectMocks
+    private OrderCommandServiceImpl orderCommandService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderDetailRepository orderDetailRepository;
+
+    @Mock
+    private DeliveryRepository deliveryRepository;
+
+    @Mock
+    private JpaWarehouseInventoryRepository jpaWarehouseInventoryRepository;
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock rLock;
+
+    private OrderCreateRequest validRequest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this); // Mockito 초기화
+        given(redissonClient.getLock(anyString())).willReturn(rLock);
+
+        validRequest = OrderCreateRequest.builder()
+                .franchiseId(1L)
+                .deliveryDueDate(LocalDate.now().plusDays(3))
+                .orderDetails(List.of(
+                        OrderDetailCreateRequest.builder()
+                                .productId(1L)
+                                .quantity(3)
+                                .build()
+                ))
+                .build();
+    }
+
+    @Test
+    @DisplayName("[주문 등록] 성공 테스트")
+    void testCreateOrderSuccess() throws Exception {
+        // given
+        WarehouseInventory inventory = WarehouseInventory.builder()
+                .productId(1L)
+                .quantity(100)
+                .reservedQuantity(10)
+                .build();
+
+        Order savedOrder = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(validRequest.getDeliveryDueDate())
+                .productCount(1)
+                .totalQuantity(3)
+                .totalPrice(4500L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        ReflectionTestUtils.setField(savedOrder, "orderId", 1L);
+
+        given(rLock.tryLock(anyLong(), anyLong(), any())).willReturn(true);
+        given(jpaWarehouseInventoryRepository.findByProductIdForUpdate(1L)).willReturn(Optional.of(inventory));
+        given(orderRepository.save(any(Order.class))).willReturn(savedOrder);
+
+        // when
+        OrderCommandResponse response = orderCommandService.createOrder(validRequest, 100L);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(1L);
+        assertThat(response.getFranchiseId()).isEqualTo(1L);
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.REQUESTED);
+
+        verify(orderRepository).save(any());
+        verify(orderDetailRepository).saveAll(any());
+        verify(rLock).unlock();
+    }
+
+    @Test
+    @DisplayName("[주문 등록] 재고 락 획득 실패 예외 테스트")
+    void testCreateOrderLockFail() throws Exception {
+        // given
+        given(rLock.tryLock(anyLong(), anyLong(), any())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.createOrder(validRequest, 100L))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.INVENTORY_LOCK_TIMEOUT);
+    }
+
+    @Test
+    @DisplayName("[주문 등록] 빈 주문 상세 예외 테스트")
+    void testCreateOrderEmptyDetails() throws Exception {
+        // given
+        OrderCreateRequest emptyRequest = OrderCreateRequest.builder()
+                .franchiseId(1L)
+                .deliveryDueDate(LocalDate.now())
+                .orderDetails(List.of())
+                .build();
+
+        given(rLock.tryLock(anyLong(), anyLong(), any())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.createOrder(emptyRequest, 100L))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.EMPTY_ORDER_DETAIL);
+    }
+
+    @Test
+    @DisplayName("[주문 수정] 성공 테스트")
+    void testUpdateOrderSuccess() {
+        // given
+        Long orderId = 1L;
+        Long memberId = 100L;
+
+        OrderUpdateRequest updateRequest = OrderUpdateRequest.builder()
+                .deliveryDueDate(LocalDate.of(2025, 6, 28))
+                .orderDetails(List.of(
+                        OrderDetailUpdateRequest.builder().productId(1L).quantity(3).build(),
+                        OrderDetailUpdateRequest.builder().productId(2L).quantity(2).build()
+                ))
+                .build();
+
+        Order existingOrder = Order.builder()
+                .franchiseId(1L)
+                .memberId(memberId)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(1)
+                .totalPrice(1000L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(existingOrder, "orderId", orderId);
+
+        WarehouseInventory inventory1 = WarehouseInventory.builder().productId(1L).quantity(100).reservedQuantity(10).build();
+        WarehouseInventory inventory2 = WarehouseInventory.builder().productId(2L).quantity(100).reservedQuantity(5).build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(existingOrder));
+        given(jpaWarehouseInventoryRepository.findByProductIdForUpdate(1L)).willReturn(Optional.of(inventory1));
+        given(jpaWarehouseInventoryRepository.findByProductIdForUpdate(2L)).willReturn(Optional.of(inventory2));
+
+        // when
+        OrderCommandResponse response = orderCommandService.updateOrder(orderId, updateRequest, memberId);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(orderId);
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.REQUESTED);
+        verify(orderDetailRepository).deleteAllByOrderId(orderId);
+        verify(orderDetailRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("[주문 수정] 권한 불일치 예외 테스트")
+    void testUpdateOrder_InvalidOwner() {
+        // given
+        Long orderId = 1L;
+        Long memberId = 999L; // 다른 유저
+
+        OrderUpdateRequest updateRequest = OrderUpdateRequest.builder()
+                .deliveryDueDate(LocalDate.of(2025, 6, 28))
+                .orderDetails(List.of(
+                        OrderDetailUpdateRequest.builder().productId(1L).quantity(3).build()
+                ))
+                .build();
+
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(1)
+                .totalPrice(1000L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.updateOrder(orderId, updateRequest, memberId))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.UNAUTHORIZED_ORDER_ACCESS);
+    }
+
+
+    @Test
+    @DisplayName("[주문 취소] 성공 테스트")
+    void testCancelOrderSuccess() {
+        // given
+        Long orderId = 1L;
+        Long memberId = 100L;
+
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(memberId)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(2)
+                .totalQuantity(5)
+                .totalPrice(7500L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when
+        OrderCommandResponse response = orderCommandService.cancelOrder(orderId, memberId);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(orderId);
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("[주문 취소] 주문자 본인이 아닐 때 예외 발생")
+    void testCancelOrder_NotOwner() {
+        // given
+        Long orderId = 1L;
+        Long otherMemberId = 999L;
+
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(2)
+                .totalQuantity(5)
+                .totalPrice(7500L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.cancelOrder(orderId, otherMemberId))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.UNAUTHORIZED_ORDER_ACCESS);
+    }
+
+    @Test
+    @DisplayName("[주문 취소] 이미 취소된 주문에 대해 예외 발생")
+    void testCancelOrder_AlreadyCancelled() {
+        // given
+        Long orderId = 1L;
+        Long memberId = 100L;
+
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(memberId)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(2)
+                .totalQuantity(5)
+                .totalPrice(7500L)
+                .orderStatus(OrderStatus.CANCELLED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.cancelOrder(orderId, memberId))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.CANNOT_CANCEL_ORDER);
+    }
+
+    @Test
+    @DisplayName("[주문 승인] 성공 테스트")
+    void testApproveOrderSuccess() {
+        // given
+        Long orderId = 1L;
+        Long approverId = 200L;
+
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(3)
+                .totalPrice(4500L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        OrderDetail detail = OrderDetail.builder()
+                .orderId(orderId)
+                .productId(1L)
+                .quantity(3)
+                .unitPrice(1500)
+                .totalPrice(4500L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        WarehouseInventory inventory = WarehouseInventory.builder()
+                .productId(1L)
+                .quantity(100)
+                .reservedQuantity(10)
+                .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(orderDetailRepository.findByOrderId(orderId)).willReturn(List.of(detail));
+        given(jpaWarehouseInventoryRepository.findByProductIdForUpdate(1L)).willReturn(Optional.of(inventory));
+        given(deliveryRepository.save(any())).willReturn(any());
+
+        // when
+        OrderCommandResponse response = orderCommandService.approveOrder(orderId, approverId);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(orderId);
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.APPROVED);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.APPROVED);
+
+        verify(deliveryRepository).save(any(Delivery.class));
+        verify(jpaWarehouseInventoryRepository).findByProductIdForUpdate(1L);
+    }
+
+    @Test
+    @DisplayName("[주문 승인] 주문 상태가 REQUESTED가 아닌 경우 예외 발생")
+    void testApproveOrder_InvalidStatus() {
+        // given
+        Long orderId = 1L;
+
+        Order alreadyApproved = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(3)
+                .totalPrice(4500L)
+                .orderStatus(OrderStatus.APPROVED) // 이미 승인됨
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(alreadyApproved, "orderId", orderId);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(alreadyApproved));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.approveOrder(orderId, 200L))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.CANNOT_APPROVE_ORDER);
+    }
+
+    @Test
+    @DisplayName("[주문 승인] 재고 없음 예외 발생")
+    void testApproveOrder_NoInventory() {
+        // given
+        Long orderId = 1L;
+
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(3)
+                .totalPrice(4500L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        OrderDetail detail = OrderDetail.builder()
+                .orderId(orderId)
+                .productId(1L)
+                .quantity(3)
+                .unitPrice(1500)
+                .totalPrice(4500L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(orderDetailRepository.findByOrderId(orderId)).willReturn(List.of(detail));
+        given(jpaWarehouseInventoryRepository.findByProductIdForUpdate(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.approveOrder(orderId, 200L))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.PRODUCT_INVENTORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[주문 반려] 성공 테스트")
+    void testRejectOrderSuccess() {
+        // given
+        Long orderId = 1L;
+        Long memberId = 200L;
+
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(3)
+                .totalPrice(4500L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        OrderRejectRequest rejectRequest = OrderRejectRequest.builder()
+                .rejectReason("재고 부족으로 반려합니다.")
+                .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when
+        OrderCommandResponse response = orderCommandService.rejectOrder(orderId, rejectRequest, memberId);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(orderId);
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.REJECTED);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.REJECTED);
+        assertThat(order.getRejectReason()).isEqualTo(rejectRequest.getRejectReason());
+    }
+
+    @Test
+    @DisplayName("[주문 반려] 주문 상태가 REQUESTED가 아닐 경우 예외 발생")
+    void testRejectOrder_InvalidStatus() {
+        // given
+        Long orderId = 1L;
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(3)
+                .totalPrice(4500L)
+                .orderStatus(OrderStatus.APPROVED) // 이미 승인됨
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        OrderRejectRequest rejectRequest = OrderRejectRequest.builder()
+                .rejectReason("사유")
+                .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.rejectOrder(orderId, rejectRequest, 200L))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.CANNOT_REJECT_ORDER);
+    }
+
+    @Test
+    @DisplayName("[주문 반려] 반려 사유 누락 시 예외 발생")
+    void testRejectOrder_BlankReason() {
+        // given
+        Long orderId = 1L;
+        Order order = Order.builder()
+                .franchiseId(1L)
+                .memberId(100L)
+                .orderCode("SO-240623001")
+                .deliveryDueDate(LocalDate.now())
+                .productCount(1)
+                .totalQuantity(3)
+                .totalPrice(4500L)
+                .orderStatus(OrderStatus.REQUESTED)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+
+        OrderRejectRequest rejectRequest = OrderRejectRequest.builder()
+                .rejectReason(" ") // 공백 문자열
+                .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.rejectOrder(orderId, rejectRequest, 200L))
+                .isInstanceOf(OrderException.class)
+                .hasFieldOrPropertyWithValue("errorCode", OrderErrorCode.REJECT_REASON_REQUIRED);
+    }
+
+
+}

--- a/src/test/java/com/harusari/chainware/securitysupport/MemberTestFactory.java
+++ b/src/test/java/com/harusari/chainware/securitysupport/MemberTestFactory.java
@@ -1,0 +1,56 @@
+package com.harusari.chainware.securitysupport;
+
+import com.harusari.chainware.member.command.domain.aggregate.Member;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class MemberTestFactory {
+
+    public static Member testMaster(Long id) {
+        return createMember(id, 1, "master@domain.com", "MASTER");
+    }
+
+    public static Member testGeneralManager(Long id) {
+        return createMember(id, 2, "general@domain.com", "GENERAL_MANAGER");
+    }
+
+    public static Member testSeniorManager(Long id) {
+        return createMember(id, 3, "senior@domain.com", "SENIOR_MANAGER");
+    }
+
+    public static Member testWarehouseManager(Long id) {
+        return createMember(id, 4, "warehouse@domain.com", "WAREHOUSE_MANAGER");
+    }
+
+    public static Member testFranchiseManager(Long id) {
+        return createMember(id, 5, "franchise@domain.com", "FRANCHISE_MANAGER");
+    }
+
+    public static Member testVendorManager(Long id) {
+        return createMember(id, 6, "vendor@domain.com", "VENDOR_MANAGER");
+    }
+
+    public static Member testSystem(Long id) {
+        return createMember(id, 99, "system@domain.com", "SYSTEM");
+    }
+
+    private static Member createMember(Long id, int authorityId, String email, String position) {
+        Member member = Member.builder()
+                .authorityId(authorityId)
+                .email(email)
+                .password("encodedPassword")
+                .name("테스트 유저")
+                .phoneNumber("010-1111-2222")
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .position(position)
+                .modifiedAt(LocalDateTime.now())
+                .isDeleted(false)
+                .build();
+
+        ReflectionTestUtils.setField(member, "memberId", id);
+        return member;
+    }
+}
+

--- a/src/test/java/com/harusari/chainware/securitysupport/WithMockCustomUser.java
+++ b/src/test/java/com/harusari/chainware/securitysupport/WithMockCustomUser.java
@@ -1,0 +1,17 @@
+package com.harusari.chainware.securitysupport;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    long memberId() default 1L;
+    String position() default "FRANCHISE_MANAGER"; // 기본값 설정
+}
+

--- a/src/test/java/com/harusari/chainware/securitysupport/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/harusari/chainware/securitysupport/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,40 @@
+package com.harusari.chainware.securitysupport;
+
+import com.harusari.chainware.auth.model.CustomUserDetails;
+import com.harusari.chainware.member.command.domain.aggregate.Member;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        Member member = createMemberByPosition(annotation.position(), annotation.memberId());
+        CustomUserDetails principal = new CustomUserDetails(member);
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities());
+
+        context.setAuthentication(auth);
+        return context;
+    }
+
+    private Member createMemberByPosition(String position, Long memberId) {
+        return switch (position.toUpperCase()) {
+            case "MASTER" -> MemberTestFactory.testMaster(memberId);
+            case "GENERAL_MANAGER" -> MemberTestFactory.testGeneralManager(memberId);
+            case "SENIOR_MANAGER" -> MemberTestFactory.testSeniorManager(memberId);
+            case "WAREHOUSE_MANAGER" -> MemberTestFactory.testWarehouseManager(memberId);
+            case "FRANCHISE_MANAGER" -> MemberTestFactory.testFranchiseManager(memberId);
+            case "VENDOR_MANAGER" -> MemberTestFactory.testVendorManager(memberId);
+            case "SYSTEM" -> MemberTestFactory.testSystem(memberId);
+            default -> throw new IllegalArgumentException("Invalid position: " + position);
+        };
+    }
+}
+


### PR DESCRIPTION
Closes #35

## 🔥 작업 내용  
- 주문 등록/수정/승인에 동시성 제어 추가(비관적 락 & 분산락)
- 예외 처리 추가
- 테스트코드 작성

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ⚙️ 특이사항
- 분산락 적용을 위한 Redisson이 build.gradle에 추가됨
- 테스트 코드에서 Security&CustomUserDetails 적용하기 위해 MemberTestFactory, WithMockCustomUser, WithMockCustomUserSecurityContextFactory 적용 -> 주문 테스트코드 참고해서 권한 별로 멤버 부여

## ✨ 관련 이슈
- #35
