### PR TITLE
feat: 회원 정보 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -17,7 +17,8 @@ public class SecurityPolicy {
             "/api/v1/members/franchise",
             "/api/v1/members/vendor",
             "/api/v1/members/warehouse",
-            "/api/v1/members"
+            "/api/v1/members",
+            "/api/v1/members/{memberId}",
     };
 
     protected static final String[] GENERAL_MANAGER_URLS = {

--- a/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
@@ -4,6 +4,7 @@ import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.harusari.chainware.member.query.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,17 @@ public class MemberQueryController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(pageResponse));
+    }
+
+    @GetMapping("/members/{memberId}")
+    public ResponseEntity<ApiResponse<MemberSearchDetailResponse>> getMemberDetail(
+            @PathVariable(name = "memberId") Long memberId
+    ) {
+        MemberSearchDetailResponse memberSearchDetailResponse = memberQueryService.getMemberDetail(memberId);
+
+        return  ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(memberSearchDetailResponse));
     }
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/dto/response/MemberSearchDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/member/query/dto/response/MemberSearchDetailResponse.java
@@ -1,0 +1,14 @@
+package com.harusari.chainware.member.query.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record MemberSearchDetailResponse(
+        Long memberId, String email, String name, String authorityLabelKr,
+        String phoneNumber, LocalDate birthDate, String position,
+        LocalDateTime joinAt, LocalDateTime modifiedAt, boolean isDeleted
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.member.query.repository;
 
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,5 +16,7 @@ public interface MemberQueryRepositoryCustom {
     Optional<Member> findActiveMemberByEmail(String email);
 
     Page<MemberSearchResponse> findMembers(MemberSearchRequest condition, Pageable pageable);
+
+    Optional<MemberSearchDetailResponse> findMemberSearchDetailById(Long memberId);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.member.query.repository;
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -85,6 +86,22 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
         long total = Optional.ofNullable(result).orElse(TOTAL_DEFAULT_VALUE);
 
         return new PageImpl<>(contents, pageable, total);
+    }
+
+    @Override
+    public Optional<MemberSearchDetailResponse> findMemberSearchDetailById(Long memberId) {
+        return Optional.ofNullable(queryFactory
+                .select(Projections.constructor(MemberSearchDetailResponse.class,
+                        member.memberId, member.email, member.name,
+                        authority.authorityLabelKr, member.phoneNumber,
+                        member.birthDate, member.position, member.joinAt,
+                        member.modifiedAt, member.isDeleted
+                ))
+                .from(member)
+                .leftJoin(authority).on(member.authorityId.eq(authority.authorityId))
+                .where(member.memberId.eq(memberId))
+                .fetchOne()
+        );
     }
 
     private BooleanExpression emailEq(String email) {

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.member.query.service;
 
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,5 +12,7 @@ public interface MemberQueryService {
     EmailExistsResponse checkEmailDuplicate(String email);
 
     Page<MemberSearchResponse> searchMembers(MemberSearchRequest memberSearchRequest, Pageable pageable);
+
+    MemberSearchDetailResponse getMemberDetail(Long memberId);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
@@ -1,7 +1,9 @@
 package com.harusari.chainware.member.query.service;
 
+import com.harusari.chainware.exception.auth.MemberNotFoundException;
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.harusari.chainware.member.query.repository.MemberQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+import static com.harusari.chainware.exception.auth.AuthErrorCode.MEMBER_NOT_FOUND_EXCEPTION;
 import static com.harusari.chainware.member.common.constants.EmailValidationConstant.EMAIL_VALIDATION_PREFIX;
 import static com.harusari.chainware.member.common.constants.EmailValidationConstant.EMAIL_VALIDATION_TTL;
 
@@ -44,6 +47,12 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     @Override
     public Page<MemberSearchResponse> searchMembers(MemberSearchRequest memberSearchRequest, Pageable pageable) {
         return memberQueryRepository.findMembers(memberSearchRequest, pageable);
+    }
+
+    @Override
+    public MemberSearchDetailResponse getMemberDetail(Long memberId) {
+        return memberQueryRepository.findMemberSearchDetailById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
     }
 
     private String generateAndStoreEmailValidationToken(String email) {


### PR DESCRIPTION
Closes #59

## 🔥 작업 내용  
- 회원 정보 상세 조회 API 구현
- 회원 정보 상세 응답 데이터에 `memberId`, 이메일, 이름, 권한명, 전화번호, 생년월일, 부서, 가입일시, 수정일시, 탈퇴 여부를 포함시키는 DTO 생성
- `member`와 `authority` 테이블을 조인하여 회원 정보를 가져오는 쿼리 작성
- `SecurityPolicy` `MASTER_ONLY_URLS`에 회원 정보 상세 조회 API 추가


## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #59 
