### PR TITLE
feat: 회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
@@ -4,6 +4,7 @@ import com.harusari.chainware.auth.model.CustomUserDetails;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
+import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
@@ -77,6 +78,18 @@ public class MemberCommandController {
         memberCommandService.changePassword(passwordChangeRequest, email);
 
         return  ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(null));
+    }
+
+    @PutMapping("/members/{memberId}")
+    public ResponseEntity<ApiResponse<Void>> updateMember(
+            @PathVariable(name = "memberId") Long memberId,
+            @RequestBody UpdateMemberRequest updateMemberRequest
+    ) {
+        memberCommandService.updateMemberRequest(memberId, updateMemberRequest);
+
+        return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(null));
     }

--- a/src/main/java/com/harusari/chainware/member/command/application/dto/request/UpdateMemberRequest.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/dto/request/UpdateMemberRequest.java
@@ -1,0 +1,11 @@
+package com.harusari.chainware.member.command.application.dto.request;
+
+import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
+import lombok.Builder;
+
+@Builder
+public record UpdateMemberRequest(
+        String name, MemberAuthorityType authorityName,
+        String phoneNumber, String position, boolean isDeleted
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.member.command.application.service;
 
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
+import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
@@ -18,5 +19,7 @@ public interface MemberCommandService {
     void registerWarehouse(MemberWithWarehouseRequest memberWithWarehouseRequest);
 
     void changePassword(PasswordChangeRequest passwordChangeRequest, String email);
+
+    void updateMemberRequest(Long memberId, UpdateMemberRequest updateMemberRequest);
 
 }

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
@@ -1,9 +1,11 @@
 package com.harusari.chainware.member.command.application.service;
 
+import com.harusari.chainware.exception.auth.MemberNotFoundException;
 import com.harusari.chainware.exception.member.*;
 import com.harusari.chainware.franchise.command.application.service.FranchiseCommandService;
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
+import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
@@ -25,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import static com.harusari.chainware.exception.auth.AuthErrorCode.MEMBER_NOT_FOUND_EXCEPTION;
 import static com.harusari.chainware.exception.member.MemberErrorCode.*;
 import static com.harusari.chainware.member.common.constants.EmailValidationConstant.EMAIL_VALIDATION_PREFIX;
 
@@ -110,6 +113,16 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         String encodedPassword = passwordEncoder.encode(passwordChangeRequest.newPassword());
         member.updateEncodedPassword(encodedPassword);
+    }
+
+    @Override
+    public void updateMemberRequest(Long memberId, UpdateMemberRequest updateMemberRequest) {
+        Member member = memberCommandRepository.findMemberByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
+
+        Authority authority = authorityCommandRepository.findByAuthorityName(updateMemberRequest.authorityName());
+
+        member.updateMember(authority.getAuthorityId(), updateMemberRequest);
     }
 
     private Member registerMember(MemberCreateRequest memberCreateRequest) {

--- a/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.member.command.domain.aggregate;
 
+import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -72,6 +73,15 @@ public class Member {
 
     public void updateAuthorityId(Integer authorityId) {
         this.authorityId = authorityId;
+    }
+
+    public void updateMember(Integer authorityId, UpdateMemberRequest updateMemberRequest) {
+        this.authorityId = authorityId;
+        this.name = updateMemberRequest.name();
+        this.phoneNumber = updateMemberRequest.phoneNumber();
+        this.position = updateMemberRequest.position();
+        this.modifiedAt = LocalDateTime.now().withNano(0);
+        this.isDeleted = updateMemberRequest.isDeleted();
     }
 
 }

--- a/src/main/java/com/harusari/chainware/member/command/domain/repository/MemberCommandRepository.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/repository/MemberCommandRepository.java
@@ -2,10 +2,14 @@ package com.harusari.chainware.member.command.domain.repository;
 
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 
+import java.util.Optional;
+
 public interface MemberCommandRepository {
 
     boolean existsByEmail(String email);
 
     Member save(Member member);
+
+    Optional<Member> findMemberByMemberId(Long memberId);
 
 }


### PR DESCRIPTION
Closes #54 

## 🔥 작업 내용  
- 회원 정보 수정 API 구현
- `SecurityPolicy`에 회원 정보 수정 API를 마스터 권한에 등록
- `memberId`로 회원 정보를 조회하는 기능 구현
- 이름, 권한, 전화번호, 직책, 탈퇴 여부를 수정하는 기능을 구현

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #54 
