### PR TITLE
feat: 회원 로그인 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
+++ b/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.harusari.chainware.auth.dto.request.RefreshTokenRequest;
 import com.harusari.chainware.auth.dto.response.TokenResponse;
 import com.harusari.chainware.auth.service.AuthService;
 import com.harusari.chainware.common.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,9 +23,11 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenResponse>> login(
-            @RequestBody LoginRequest loginRequest
+            @RequestBody LoginRequest loginRequest,
+            HttpServletRequest httpServletRequest
     ) {
-        TokenResponse token = authService.login(loginRequest);
+        TokenResponse token = authService.login(loginRequest, httpServletRequest);
+
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(token));

--- a/src/main/java/com/harusari/chainware/auth/service/AuthService.java
+++ b/src/main/java/com/harusari/chainware/auth/service/AuthService.java
@@ -2,10 +2,11 @@ package com.harusari.chainware.auth.service;
 
 import com.harusari.chainware.auth.dto.request.LoginRequest;
 import com.harusari.chainware.auth.dto.response.TokenResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthService {
 
-    TokenResponse login(LoginRequest loginRequest);
+    TokenResponse login(LoginRequest loginRequest, HttpServletRequest httpServletRequest);
 
     TokenResponse refreshToken(String refreshToken);
 

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -25,6 +25,7 @@ public enum SecurityPolicy {
     MEMBER_WAREHOUSE_POST("/api/v1/members/warehouse", POST, ROLE_BASED, List.of(MASTER)),
     MEMBERS_GET("/api/v1/members", GET, ROLE_BASED, List.of(MASTER)), // 회원 정보 조회
     MEMBERS_DETAIL_GET("/api/v1/members/{memberId}", GET, ROLE_BASED, List.of(MASTER)), // 회원 정보 상세 조회
+    LOGIN_HISTORY_GET("/api/v1/members/{memberId}/login-history", GET, ROLE_BASED, List.of(MASTER)),
 
     // Permit All
     LOGIN_POST("/api/v1/auth/login", POST, PERMIT_ALL, List.of()), // 로그인

--- a/src/main/java/com/harusari/chainware/member/command/domain/aggregate/LoginHistory.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/aggregate/LoginHistory.java
@@ -1,0 +1,41 @@
+package com.harusari.chainware.member.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "login_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginHistory {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "login_history_id")
+    private Long loginHistoryId;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "login_at")
+    private LocalDateTime loginAt;
+
+    @Column(name = "ip_address")
+    private String ipAddress;
+
+    @Column(name = "browser")
+    private String browser;
+
+    @Builder
+    public LoginHistory(Long memberId, String ipAddress, String browser) {
+        this.memberId = memberId;
+        this.loginAt = LocalDateTime.now().withNano(0);
+        this.ipAddress = ipAddress;
+        this.browser = browser;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/member/command/domain/repository/LoginHistoryCommandRepository.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/repository/LoginHistoryCommandRepository.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.member.command.domain.repository;
+
+import com.harusari.chainware.member.command.domain.aggregate.LoginHistory;
+
+public interface LoginHistoryCommandRepository {
+
+    LoginHistory save(LoginHistory loginHistory);
+
+}

--- a/src/main/java/com/harusari/chainware/member/command/infrastructure/repository/JpaLoginHistoryCommandRepository.java
+++ b/src/main/java/com/harusari/chainware/member/command/infrastructure/repository/JpaLoginHistoryCommandRepository.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.member.command.infrastructure.repository;
+
+import com.harusari.chainware.member.command.domain.aggregate.LoginHistory;
+import com.harusari.chainware.member.command.domain.repository.LoginHistoryCommandRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaLoginHistoryCommandRepository extends LoginHistoryCommandRepository, JpaRepository<LoginHistory, Long> {
+
+}

--- a/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
@@ -4,6 +4,7 @@ import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.harusari.chainware.member.query.service.MemberQueryService;
@@ -55,6 +56,19 @@ public class MemberQueryController {
         return  ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(memberSearchDetailResponse));
+    }
+
+    @GetMapping("/members/{memberId}/login-history")
+    public ResponseEntity<ApiResponse<PageResponse<LoginHistoryResponse>>> searchLoginHistory(
+        @PathVariable(name = "memberId") Long memberId,
+        @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<LoginHistoryResponse> loginHistoryResponse = memberQueryService.searchMemberLoginHistory(memberId, pageable);
+        PageResponse<LoginHistoryResponse> pageResponse = PageResponse.from(loginHistoryResponse);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(pageResponse));
     }
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/dto/response/LoginHistoryResponse.java
+++ b/src/main/java/com/harusari/chainware/member/query/dto/response/LoginHistoryResponse.java
@@ -1,0 +1,11 @@
+package com.harusari.chainware.member.query.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record LoginHistoryResponse(
+        Long memberId, LocalDateTime loginAt, String ipAddress, String browser
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.member.query.repository;
 
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import org.springframework.data.domain.Page;
@@ -18,5 +19,7 @@ public interface MemberQueryRepositoryCustom {
     Page<MemberSearchResponse> findMembers(MemberSearchRequest condition, Pageable pageable);
 
     Optional<MemberSearchDetailResponse> findMemberSearchDetailById(Long memberId);
+
+    Page<LoginHistoryResponse> findLoginHistoryByMemberId(Long memberId, Pageable pageable);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.member.query.repository;
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.querydsl.core.types.Projections;
@@ -21,10 +22,13 @@ import java.util.Optional;
 
 import static com.harusari.chainware.member.command.domain.aggregate.QAuthority.authority;
 import static com.harusari.chainware.member.command.domain.aggregate.QMember.member;
+import static com.harusari.chainware.member.command.domain.aggregate.QLoginHistory.loginHistory;
 
 @Repository
 @RequiredArgsConstructor
 public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
+
+    private static final long TOTAL_DEFAULT_VALUE = 0L;
 
     private final JPAQueryFactory queryFactory;
 
@@ -82,7 +86,6 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
                 )
                 .fetchOne();
 
-        final long TOTAL_DEFAULT_VALUE = 0L;
         long total = Optional.ofNullable(result).orElse(TOTAL_DEFAULT_VALUE);
 
         return new PageImpl<>(contents, pageable, total);
@@ -102,6 +105,31 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
                 .where(member.memberId.eq(memberId))
                 .fetchOne()
         );
+    }
+
+    @Override
+    public Page<LoginHistoryResponse> findLoginHistoryByMemberId(Long memberId, Pageable pageable) {
+        List<LoginHistoryResponse> contents = queryFactory
+                .select(Projections.constructor(LoginHistoryResponse.class,
+                        loginHistory.memberId, loginHistory.loginAt,
+                        loginHistory.ipAddress, loginHistory.browser
+                ))
+                .from(loginHistory)
+                .where(loginHistory.memberId.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(loginHistory.loginAt.desc())
+                .fetch();
+
+        Long result = queryFactory
+                .select(loginHistory.count())
+                .from(loginHistory)
+                .where(loginHistory.memberId.eq(memberId))
+                .fetchOne();
+
+        long total = Optional.ofNullable(result).orElse(TOTAL_DEFAULT_VALUE);
+
+        return new PageImpl<>(contents, pageable, total);
     }
 
     private BooleanExpression emailEq(String email) {

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.member.query.service;
 
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import org.springframework.data.domain.Page;
@@ -14,5 +15,7 @@ public interface MemberQueryService {
     Page<MemberSearchResponse> searchMembers(MemberSearchRequest memberSearchRequest, Pageable pageable);
 
     MemberSearchDetailResponse getMemberDetail(Long memberId);
+
+    Page<LoginHistoryResponse> searchMemberLoginHistory(Long memberId, Pageable pageable);
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.member.query.service;
 import com.harusari.chainware.exception.auth.MemberNotFoundException;
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
 import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
+import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.harusari.chainware.member.query.repository.MemberQueryRepository;
@@ -53,6 +54,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     public MemberSearchDetailResponse getMemberDetail(Long memberId) {
         return memberQueryRepository.findMemberSearchDetailById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
+    }
+
+    @Override
+    public Page<LoginHistoryResponse> searchMemberLoginHistory(Long memberId, Pageable pageable) {
+        return memberQueryRepository.findLoginHistoryByMemberId(memberId, pageable);
     }
 
     private String generateAndStoreEmailValidationToken(String email) {


### PR DESCRIPTION
Closes #68

## 🔥 작업 내용  
- 로그인 시 로그인 내역 테이블에 접속일시, IP주소, 브라우저 정보를 저장하는 기능 구현
- 로그인 내역 조회하는 API 구현
- `memberId`로 로그인 내역을 조회하는 기능 구현
  - 로그인 일시를 기준으로 내림차순 정렬하는 기능 구현

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ⚙️ 특이사항
- 로그인 내역 테이블에서 ip_address 컬럼 VARCHAR(15)에서 VARCHAR(39)로 변경했습니다. 
- 노션에 올라가 있는 ddl-v20 확인해주세요.

## ✨ 관련 이슈
- #68 
