### PR TITLE
refactor: MapStruct 불필요한 옵션 제거 및 디렉토리명을 mapper에서 mapstruct으로 변경

### DIFF
--- a/src/main/java/com/harusari/chainware/franchise/command/application/service/FranchiseCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/command/application/service/FranchiseCommandServiceImpl.java
@@ -3,7 +3,7 @@ package com.harusari.chainware.franchise.command.application.service;
 import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
 import com.harusari.chainware.franchise.command.domain.repository.FranchiseRepository;
 import com.harusari.chainware.common.infrastructure.storage.StorageUploader;
-import com.harusari.chainware.franchise.common.mapper.FranchiseMapStruct;
+import com.harusari.chainware.franchise.common.mapstruct.FranchiseMapStruct;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/harusari/chainware/franchise/common/mapstruct/FranchiseMapStruct.java
+++ b/src/main/java/com/harusari/chainware/franchise/common/mapstruct/FranchiseMapStruct.java
@@ -1,14 +1,10 @@
-package com.harusari.chainware.franchise.common.mapper;
+package com.harusari.chainware.franchise.common.mapstruct;
 
 import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
 import com.harusari.chainware.member.command.application.dto.request.franchise.FranchiseCreateRequest;
 import org.mapstruct.Mapper;
-import org.mapstruct.ReportingPolicy;
 
-@Mapper(
-        unmappedSourcePolicy =  ReportingPolicy.WARN,
-        unmappedTargetPolicy = ReportingPolicy.WARN
-)
+@Mapper
 public interface FranchiseMapStruct {
 
     Franchise toFranchise(FranchiseCreateRequest franchiseCreateRequest, Long memberId);

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
@@ -15,11 +15,11 @@ import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityTyp
 import com.harusari.chainware.member.command.domain.repository.AuthorityCommandRepository;
 import com.harusari.chainware.member.command.domain.repository.MemberCommandRepository;
 import com.harusari.chainware.member.command.domain.repository.MemberCommandRepositoryCustom;
-import com.harusari.chainware.member.common.mapper.MemberMapStruct;
+import com.harusari.chainware.member.common.mapstruct.MemberMapStruct;
 import com.harusari.chainware.vendor.command.application.service.VendorCommandService;
 import com.harusari.chainware.warehouse.command.domain.aggregate.Warehouse;
 import com.harusari.chainware.warehouse.command.domain.repository.WarehouseRepository;
-import com.harusari.chainware.warehouse.common.mapper.WarehouseMapStruct;
+import com.harusari.chainware.warehouse.common.mapstruct.WarehouseMapStruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/com/harusari/chainware/member/common/mapstruct/MemberMapStruct.java
+++ b/src/main/java/com/harusari/chainware/member/common/mapstruct/MemberMapStruct.java
@@ -1,14 +1,10 @@
-package com.harusari.chainware.member.common.mapper;
+package com.harusari.chainware.member.common.mapstruct;
 
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import org.mapstruct.Mapper;
-import org.mapstruct.ReportingPolicy;
 
-@Mapper(
-        unmappedSourcePolicy =  ReportingPolicy.WARN,
-        unmappedTargetPolicy = ReportingPolicy.WARN
-)
+@Mapper
 public interface MemberMapStruct {
 
     Member toMember(MemberCreateRequest memberCreateRequest);

--- a/src/main/java/com/harusari/chainware/vendor/command/application/service/VendorCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/vendor/command/application/service/VendorCommandServiceImpl.java
@@ -7,7 +7,7 @@ import com.harusari.chainware.vendor.command.application.dto.VendorStatusChangeR
 import com.harusari.chainware.vendor.command.application.dto.VendorUpdateRequestDto;
 import com.harusari.chainware.vendor.command.domain.aggregate.Vendor;
 import com.harusari.chainware.vendor.command.domain.repository.VendorRepository;
-import com.harusari.chainware.vendor.common.mapper.VendorMapStruct;
+import com.harusari.chainware.vendor.common.mapstruct.VendorMapStruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/harusari/chainware/vendor/common/mapstruct/VendorMapStruct.java
+++ b/src/main/java/com/harusari/chainware/vendor/common/mapstruct/VendorMapStruct.java
@@ -1,14 +1,10 @@
-package com.harusari.chainware.vendor.common.mapper;
+package com.harusari.chainware.vendor.common.mapstruct;
 
 import com.harusari.chainware.member.command.application.dto.request.vendor.VendorCreateRequest;
 import com.harusari.chainware.vendor.command.domain.aggregate.Vendor;
 import org.mapstruct.Mapper;
-import org.mapstruct.ReportingPolicy;
 
-@Mapper(
-        unmappedSourcePolicy =  ReportingPolicy.WARN,
-        unmappedTargetPolicy = ReportingPolicy.WARN
-)
+@Mapper
 public interface VendorMapStruct {
 
     Vendor toVendor(VendorCreateRequest vendorCreateRequest, Long memberId);

--- a/src/main/java/com/harusari/chainware/warehouse/command/application/controller/WarehouseInventorySnapshotTestController.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/application/controller/WarehouseInventorySnapshotTestController.java
@@ -2,7 +2,7 @@ package com.harusari.chainware.warehouse.command.application.controller;
 
 import com.harusari.chainware.warehouse.command.application.dto.WarehouseInventorySnapshotResponseDto;
 import com.harusari.chainware.warehouse.command.application.service.InventorySnapshotScheduler;
-import com.harusari.chainware.warehouse.common.mapper.WarehouseInventorySnapshotQueryMapper;
+import com.harusari.chainware.warehouse.command.mapper.WarehouseInventorySnapshotQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/harusari/chainware/warehouse/command/application/service/InventorySnapshotSchedulerImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/application/service/InventorySnapshotSchedulerImpl.java
@@ -4,7 +4,7 @@ import com.harusari.chainware.warehouse.command.application.dto.CurrentWarehouse
 import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseInventorySnapshot;
 import com.harusari.chainware.warehouse.command.domain.repository.WarehouseInventorySnapshotRepository;
 import com.harusari.chainware.warehouse.command.infrastructure.repository.JpaWarehouseInventorySnapshotRepository;
-import com.harusari.chainware.warehouse.common.mapper.WarehouseInventorySnapshotQueryMapper;
+import com.harusari.chainware.warehouse.command.mapper.WarehouseInventorySnapshotQueryMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/harusari/chainware/warehouse/command/mapper/WarehouseInventorySnapshotQueryMapper.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/mapper/WarehouseInventorySnapshotQueryMapper.java
@@ -1,4 +1,4 @@
-package com.harusari.chainware.warehouse.common.mapper;
+package com.harusari.chainware.warehouse.command.mapper;
 
 import com.harusari.chainware.warehouse.command.application.dto.CurrentWarehouseInventoryDto;
 import com.harusari.chainware.warehouse.command.application.dto.WarehouseInventorySnapshotResponseDto;

--- a/src/main/java/com/harusari/chainware/warehouse/common/mapstruct/WarehouseMapStruct.java
+++ b/src/main/java/com/harusari/chainware/warehouse/common/mapstruct/WarehouseMapStruct.java
@@ -1,14 +1,10 @@
-package com.harusari.chainware.warehouse.common.mapper;
+package com.harusari.chainware.warehouse.common.mapstruct;
 
 import com.harusari.chainware.member.command.application.dto.request.warehouse.WarehouseCreateRequest;
 import com.harusari.chainware.warehouse.command.domain.aggregate.Warehouse;
 import org.mapstruct.Mapper;
-import org.mapstruct.ReportingPolicy;
 
-@Mapper(
-        unmappedSourcePolicy =  ReportingPolicy.WARN,
-        unmappedTargetPolicy = ReportingPolicy.WARN
-)
+@Mapper
 public interface WarehouseMapStruct {
 
     Warehouse toWarehouse(WarehouseCreateRequest warehouseCreateRequest, Long memberId);

--- a/src/main/resources/mappers/warehouse/WarehouseInventorySnapshotQueryMapper.xml
+++ b/src/main/resources/mappers/warehouse/WarehouseInventorySnapshotQueryMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.harusari.chainware.warehouse.common.mapper.WarehouseInventorySnapshotQueryMapper">
+<mapper namespace="com.harusari.chainware.warehouse.command.mapper.WarehouseInventorySnapshotQueryMapper">
 
     <select id="findAllCurrentInventory" resultType="com.harusari.chainware.warehouse.command.application.dto.CurrentWarehouseInventoryDto">
         SELECT


### PR DESCRIPTION
Closes #72 

## 🔥 작업 내용  
- `MemberMapStruct` 에서 `unmappedSourcePolicy`, `unmappedTargetPolicy` 옵션 삭제
- `VendorMapStruct` 에서 `unmappedSourcePolicy`, `unmappedTargetPolicy` 옵션 삭제
- `WarehouseMapStruct` 에서 `unmappedSourcePolicy`, `unmappedTargetPolicy` 옵션 삭제
- `FranchiseMapStruct`에서 `unmappedSourcePolicy`, `unmappedTargetPolicy` 옵션 삭제
- 디렉토리명을 `mapper`에서 `mapstruct` 으로 변경

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #72 
