### PR TITLE
docs: 회원 관련 컨트롤러에 Swagger 문서화 애노테이션 추가

### DIFF
--- a/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
+++ b/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
@@ -5,6 +5,9 @@ import com.harusari.chainware.auth.dto.request.RefreshTokenRequest;
 import com.harusari.chainware.auth.dto.response.TokenResponse;
 import com.harusari.chainware.auth.service.AuthService;
 import com.harusari.chainware.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,12 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증 API", description = "로그인, 로그아웃, 토큰 재발급 API")
 public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "로그인", description = "아이디와 비밀번호를 이용해 로그인을 수행하고 JWT 토큰을 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공")
+    })
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenResponse>> login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "로그인 요청", required = true)
             @RequestBody LoginRequest loginRequest,
             HttpServletRequest httpServletRequest
     ) {
@@ -33,8 +42,13 @@ public class AuthController {
                 .body(ApiResponse.success(token));
     }
 
+    @Operation(summary = "로그아웃", description = "리프레시 토큰을 사용하여 로그아웃을 수행합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    })
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<TokenResponse>> logout(
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "리프레시 토큰 요청", required = true)
             @RequestBody RefreshTokenRequest refreshTokenRequest
     ) {
         authService.logout(refreshTokenRequest.refreshToken());
@@ -44,8 +58,13 @@ public class AuthController {
                 .body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용해 새로운 JWT 토큰을 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공")
+    })
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> refresh(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "리프레시 토큰 요청", required = true)
             @RequestBody RefreshTokenRequest refreshTokenRequest
     ) {
         TokenResponse tokenResponse = authService.refreshToken(refreshTokenRequest.refreshToken());

--- a/src/main/java/com/harusari/chainware/config/SwaggerConfig.java
+++ b/src/main/java/com/harusari/chainware/config/SwaggerConfig.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+@Profile("local")
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -33,7 +33,7 @@ public enum SecurityPolicy {
 
     // Authenticated
     LOGOUT_POST("/api/v1/auth/logout", POST, AUTHENTICATED, List.of()), // 로그아웃
-    PASSWORD_POST("/api/v1/auth/password", POST, AUTHENTICATED, List.of()); // 비밀번호 변경
+    PASSWORD_POST("/api/v1/auth/password", POST, AUTHENTICATED, List.of()), // 비밀번호 변경
 
     /* Product */
 
@@ -70,6 +70,14 @@ public enum SecurityPolicy {
 
     /* Statistics */
 
+
+    /* Swagger */
+    SWAGGER_UI_HTML_GET("/swagger-ui.html", GET, PERMIT_ALL, List.of()),
+    SWAGGER_UI_GET("/swagger-ui/**", GET, PERMIT_ALL, List.of()),
+    SWAGGER_GET("/swagger", GET, PERMIT_ALL, List.of()),
+    API_DOCS_GET("/api-docs", GET, PERMIT_ALL, List.of()),
+    API_DOCS_ALL_GET("/api-docs/**", GET, PERMIT_ALL, List.of()),
+    V3_API_DOCS_ALL_GET("/v3/api-docs/**", GET, PERMIT_ALL, List.of());
 
     private final String path;
     private final HttpMethod method;

--- a/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
@@ -9,6 +9,10 @@ import com.harusari.chainware.member.command.application.dto.request.franchise.M
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
 import com.harusari.chainware.member.command.application.service.MemberCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,12 +23,18 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "회원 Command API", description = "회원 등록, 수정, 비밀번호 변경 API")
 public class MemberCommandController {
 
     private final MemberCommandService memberCommandService;
 
+    @Operation(summary = "본사 회원 등록", description = "본사 회원을 등록합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "본사 회원 등록 성공")
+    })
     @PostMapping("/members/headquarters")
     public ResponseEntity<ApiResponse<Void>> registerHeadquartersMember(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "본사 회원 등록 요청")
             @RequestBody MemberCreateRequest memberCreateRequest
     ) {
         memberCommandService.registerHeadquartersMember(memberCreateRequest);
@@ -34,9 +44,14 @@ public class MemberCommandController {
                 .body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "가맹점 회원 등록, 가맹점 정보 등록", description = "가맹점 회원을 등록합니다. (form-data)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "가맹점 회원 등록, 가맹점 정보 등록 성공")
+    })
     @PostMapping("/members/franchise")
     public ResponseEntity<ApiResponse<Void>> registerFranchiseMember(
             @RequestPart MemberWithFranchiseRequest memberWithFranchiseRequest,
+            @Parameter(description = "가맹점 계약서 파일 (PDF)")
             @RequestPart MultipartFile agreementFile
     ) {
         memberCommandService.registerFranchise(memberWithFranchiseRequest, agreementFile);
@@ -46,9 +61,14 @@ public class MemberCommandController {
                 .body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "거래처 회원 등록, 거래처 정보 등록", description = "거래처 회원을 등록합니다. (form-data)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "거래처 회원 등록, 거래처 정보 등록 성공")
+    })
     @PostMapping("/members/vendor")
     public ResponseEntity<ApiResponse<Void>> registerVendorMember(
             @RequestPart MemberWithVendorRequest memberWithVendorRequest,
+            @Parameter(description = "거래처 계약서 파일 (PDF)")
             @RequestPart MultipartFile agreementFile
     ) {
         memberCommandService.registerVendor(memberWithVendorRequest, agreementFile);
@@ -58,8 +78,13 @@ public class MemberCommandController {
                 .body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "창고 회원 등록, 창고 정보 등록", description = "창고 회원을 등록합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "창고 회원 등록, 창고 정보 등록 성공")
+    })
     @PostMapping("/members/warehouse")
     public ResponseEntity<ApiResponse<Void>> registerWarehouseMember(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "창고 회원 등록 요청")
             @RequestBody MemberWithWarehouseRequest memberWithWarehouseRequest
     ) {
         memberCommandService.registerWarehouse(memberWithWarehouseRequest);
@@ -69,22 +94,33 @@ public class MemberCommandController {
                 .body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "비밀번호 변경", description = "회원 비밀번호를 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공")
+    })
     @PutMapping("/members/password")
     public ResponseEntity<ApiResponse<Void>> changePassword(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "비밀번호 변경 요청")
             @RequestBody PasswordChangeRequest passwordChangeRequest,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getEmail();
         memberCommandService.changePassword(passwordChangeRequest, email);
 
-        return  ResponseEntity
+        return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 수정 성공")
+    })
     @PutMapping("/members/{memberId}")
     public ResponseEntity<ApiResponse<Void>> updateMember(
+            @Parameter(description = "회원 ID", required = true)
             @PathVariable(name = "memberId") Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "회원 수정 요청")
             @RequestBody UpdateMemberRequest updateMemberRequest
     ) {
         memberCommandService.updateMemberRequest(memberId, updateMemberRequest);

--- a/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
@@ -8,6 +8,10 @@ import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
 import com.harusari.chainware.member.query.service.MemberQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,12 +23,18 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "회원 Query API", description = "회원 정보 조회, 로그인 내역 조회 API")
 public class MemberQueryController {
 
     private final MemberQueryService memberQueryService;
 
+    @Operation(summary = "이메일 중복 확인", description = "이메일 중복 여부를 확인합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 중복 여부 확인 성공")
+    })
     @GetMapping("/members/email-exists")
     public ResponseEntity<ApiResponse<EmailExistsResponse>> checkEmailDuplicate(
+            @Parameter(description = "중복 확인할 이메일", required = true)
             @RequestParam(name = "email") String email
     ) {
         EmailExistsResponse emailExistsResponse = memberQueryService.checkEmailDuplicate(email);
@@ -34,10 +44,14 @@ public class MemberQueryController {
                 .body(ApiResponse.success(emailExistsResponse));
     }
 
+    @Operation(summary = "회원 목록 조회", description = "검색 조건에 따른 회원 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 목록 조회 성공")
+    })
     @GetMapping("/members")
     public ResponseEntity<ApiResponse<PageResponse<MemberSearchResponse>>> searchMembers(
-            @ModelAttribute MemberSearchRequest memberSearchRequest,
-            @PageableDefault(size = 10) Pageable pageable
+            @Parameter(description = "회원 검색 조건") @ModelAttribute MemberSearchRequest memberSearchRequest,
+            @Parameter(description = "페이징 정보") @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<MemberSearchResponse> members = memberQueryService.searchMembers(memberSearchRequest, pageable);
         PageResponse<MemberSearchResponse> pageResponse = PageResponse.from(members);
@@ -47,21 +61,31 @@ public class MemberQueryController {
                 .body(ApiResponse.success(pageResponse));
     }
 
+    @Operation(summary = "회원 상세 조회", description = "특정 회원의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 상세 조회 성공")
+    })
     @GetMapping("/members/{memberId}")
     public ResponseEntity<ApiResponse<MemberSearchDetailResponse>> getMemberDetail(
+            @Parameter(description = "회원 ID", required = true)
             @PathVariable(name = "memberId") Long memberId
     ) {
         MemberSearchDetailResponse memberSearchDetailResponse = memberQueryService.getMemberDetail(memberId);
 
-        return  ResponseEntity
+        return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(memberSearchDetailResponse));
     }
 
+    @Operation(summary = "회원 로그인 이력 조회", description = "회원의 로그인 이력을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 이력 조회 성공")
+    })
     @GetMapping("/members/{memberId}/login-history")
     public ResponseEntity<ApiResponse<PageResponse<LoginHistoryResponse>>> searchLoginHistory(
-        @PathVariable(name = "memberId") Long memberId,
-        @PageableDefault(size = 10) Pageable pageable
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable(name = "memberId") Long memberId,
+            @Parameter(description = "페이징 정보") @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<LoginHistoryResponse> loginHistoryResponse = memberQueryService.searchMemberLoginHistory(memberId, pageable);
         PageResponse<LoginHistoryResponse> pageResponse = PageResponse.from(loginHistoryResponse);


### PR DESCRIPTION
Closes #77 

## 🔥 작업 내용  
- `SwaggerConfig`에 `@Profile("local")`를 사용
- `AuthController`에 스웨거 어노테이션 적용
- `MemberCommandController`에 스웨거 어노테이션 적용
- `MemberQueryController` 에 스웨거 어노테이션 적용


## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인

## ✨ 관련 이슈
- #77 
