### PR TITLE
refactor: MapStruct 매핑 시 unmapped 경고 무시하도록 설정 변경

### DIFF
--- a/src/main/java/com/harusari/chainware/franchise/common/mapstruct/FranchiseMapStruct.java
+++ b/src/main/java/com/harusari/chainware/franchise/common/mapstruct/FranchiseMapStruct.java
@@ -3,8 +3,12 @@ package com.harusari.chainware.franchise.common.mapstruct;
 import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
 import com.harusari.chainware.member.command.application.dto.request.franchise.FranchiseCreateRequest;
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper
+@Mapper(
+        unmappedSourcePolicy =  ReportingPolicy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
 public interface FranchiseMapStruct {
 
     Franchise toFranchise(FranchiseCreateRequest franchiseCreateRequest, Long memberId);

--- a/src/main/java/com/harusari/chainware/member/common/mapstruct/MemberMapStruct.java
+++ b/src/main/java/com/harusari/chainware/member/common/mapstruct/MemberMapStruct.java
@@ -3,8 +3,12 @@ package com.harusari.chainware.member.common.mapstruct;
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.domain.aggregate.Member;
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper
+@Mapper(
+        unmappedSourcePolicy =  ReportingPolicy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
 public interface MemberMapStruct {
 
     Member toMember(MemberCreateRequest memberCreateRequest);

--- a/src/main/java/com/harusari/chainware/product/command/application/service/ProductCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/product/command/application/service/ProductCommandServiceImpl.java
@@ -6,7 +6,7 @@ import com.harusari.chainware.exception.product.ProductNotFoundException;
 import com.harusari.chainware.product.command.application.dto.request.ProductCreateRequest;
 import com.harusari.chainware.product.command.application.dto.request.ProductUpdateRequest;
 import com.harusari.chainware.product.command.application.dto.response.ProductCommandResponse;
-import com.harusari.chainware.product.command.application.mapper.ProductMapper;
+import com.harusari.chainware.product.common.mapstruct.ProductMapStruct;
 import com.harusari.chainware.product.command.domain.aggregate.Product;
 import com.harusari.chainware.product.command.domain.aggregate.StoreType;
 import com.harusari.chainware.product.command.domain.repository.ProductRepository;
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductCommandServiceImpl implements ProductCommandService {
 
     private final ProductRepository productRepository;
-    private final ProductMapper productMapper;
+    private final ProductMapStruct productMapstruct;
 
     /* 상품 등록 */
     @Transactional
@@ -32,7 +32,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
         String productCode = generateProductCode(request.getCategoryCode());
 
-        Product newProduct = productMapper.toEntity(request);
+        Product newProduct = productMapstruct.toEntity(request);
 
         Product productWithCode = Product.builder()
                 .categoryId(newProduct.getCategoryId())

--- a/src/main/java/com/harusari/chainware/product/common/mapstruct/ProductMapStruct.java
+++ b/src/main/java/com/harusari/chainware/product/common/mapstruct/ProductMapStruct.java
@@ -1,12 +1,16 @@
-package com.harusari.chainware.product.command.application.mapper;
+package com.harusari.chainware.product.common.mapstruct;
 
 import com.harusari.chainware.product.command.application.dto.request.ProductCreateRequest;
 import com.harusari.chainware.product.command.domain.aggregate.Product;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper
-public interface ProductMapper {
+@Mapper(
+        unmappedSourcePolicy =  ReportingPolicy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface ProductMapStruct {
 
     // productCode, productStatus, isDeleted는 매핑하지 않고 나중에 Service에서 처리
     @Mapping(target = "productCode", ignore = true)

--- a/src/main/java/com/harusari/chainware/vendor/common/mapstruct/VendorMapStruct.java
+++ b/src/main/java/com/harusari/chainware/vendor/common/mapstruct/VendorMapStruct.java
@@ -3,8 +3,12 @@ package com.harusari.chainware.vendor.common.mapstruct;
 import com.harusari.chainware.member.command.application.dto.request.vendor.VendorCreateRequest;
 import com.harusari.chainware.vendor.command.domain.aggregate.Vendor;
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper
+@Mapper(
+        unmappedSourcePolicy =  ReportingPolicy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
 public interface VendorMapStruct {
 
     Vendor toVendor(VendorCreateRequest vendorCreateRequest, Long memberId);

--- a/src/main/java/com/harusari/chainware/warehouse/common/mapstruct/WarehouseMapStruct.java
+++ b/src/main/java/com/harusari/chainware/warehouse/common/mapstruct/WarehouseMapStruct.java
@@ -3,8 +3,12 @@ package com.harusari.chainware.warehouse.common.mapstruct;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.WarehouseCreateRequest;
 import com.harusari.chainware.warehouse.command.domain.aggregate.Warehouse;
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper
+@Mapper(
+        unmappedSourcePolicy =  ReportingPolicy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
 public interface WarehouseMapStruct {
 
     Warehouse toWarehouse(WarehouseCreateRequest warehouseCreateRequest, Long memberId);


### PR DESCRIPTION
Closes #79 

## 🔥 작업 내용  
- `@Mapper`에 `unmappedSourcePolicy`, `unmappedTargetPolicy` 옵션 추가
- `ReportingPolicy.IGNORE` 설정으로 빌드 경고 무시하도록 변경
- `Product`에서 사용하는 `MapStruct`를 `ProductMapper`에서 `ProductMapStruct`으로 변경
- `ProductCommandServiceImpl`에서 잘못 `import`된 `ProductMapper` 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #79 
