### PR TITLE
feat: 가맹점 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -61,7 +61,8 @@ public enum SecurityPolicy {
     PRODUCT_DETAIL_GET("/api/v1/products/{productId}", GET, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER, WAREHOUSE_MANAGER, FRANCHISE_MANAGER)), // 제품 상세 정보 조회
 
     /* Franchise */
-    FRANCHISE_PUT("/api/v1/franchise/{franchiseId}", PUT, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 정보 수정
+    FRANCHISE_PUT("/api/v1/franchises/{franchiseId}", PUT, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 정보 수정
+    FRANCHISES_GET("/api/v1/franchises", GET, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 목록 조회
 
     /* Vendor */
 

--- a/src/main/java/com/harusari/chainware/franchise/command/application/controller/FranchiseCommandController.java
+++ b/src/main/java/com/harusari/chainware/franchise/command/application/controller/FranchiseCommandController.java
@@ -16,7 +16,7 @@ public class FranchiseCommandController {
 
     private final FranchiseCommandService franchiseCommandService;
 
-    @PutMapping("franchise/{franchiseId}")
+    @PutMapping("franchises/{franchiseId}")
     public ResponseEntity<ApiResponse<Void>> updateFranchise(
             @PathVariable(name = "franchiseId") Long franchiseId,
             @RequestPart UpdateFranchiseRequest updateFranchiseRequest,

--- a/src/main/java/com/harusari/chainware/franchise/query/controller/FranchiseQueryController.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/controller/FranchiseQueryController.java
@@ -1,0 +1,39 @@
+package com.harusari.chainware.franchise.query.controller;
+
+import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
+import com.harusari.chainware.franchise.query.service.FranchiseQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class FranchiseQueryController {
+
+    private final FranchiseQueryService franchiseQueryService;
+
+    @GetMapping("/franchises")
+    public ResponseEntity<ApiResponse<PageResponse<FranchiseSearchResponse>>> searchFranchises(
+            @ModelAttribute FranchiseSearchRequest franchiseSearchRequest,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<FranchiseSearchResponse> franchises = franchiseQueryService.searchFranchises(franchiseSearchRequest, pageable);
+        PageResponse<FranchiseSearchResponse> pageResponse = PageResponse.from(franchises);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(pageResponse));
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/dto/request/FranchiseSearchRequest.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/dto/request/FranchiseSearchRequest.java
@@ -1,0 +1,14 @@
+package com.harusari.chainware.franchise.query.dto.request;
+
+import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record FranchiseSearchRequest(
+        String franchiseName, String zipcode, String addressRoad,
+        String addressDetail, FranchiseStatus franchiseStatus,
+        LocalDate contractStartDate, LocalDate contractEndDate
+) {
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchiseSearchResponse.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchiseSearchResponse.java
@@ -1,0 +1,14 @@
+package com.harusari.chainware.franchise.query.dto.resposne;
+
+import com.harusari.chainware.common.domain.vo.Address;
+import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record FranchiseSearchResponse(
+        String franchiseName, String franchiseManager, String franchiseContact, Address franchiseAddress,
+        FranchiseStatus franchiseStatus, LocalDate contractStartDate, LocalDate contractEndDate
+) {
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepository.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepository.java
@@ -1,0 +1,8 @@
+package com.harusari.chainware.franchise.query.repository;
+
+import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FranchiseQueryRepository extends FranchiseQueryRepositoryCustom, JpaRepository<Franchise, Long> {
+
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.harusari.chainware.franchise.query.repository;
+
+import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FranchiseQueryRepositoryCustom {
+
+    Page<FranchiseSearchResponse> pageFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable);
+
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryImpl.java
@@ -1,0 +1,115 @@
+package com.harusari.chainware.franchise.query.repository;
+
+import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus;
+import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static com.harusari.chainware.franchise.command.domain.aggregate.QFranchise.franchise;
+import static com.harusari.chainware.member.command.domain.aggregate.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class FranchiseQueryRepositoryImpl implements FranchiseQueryRepositoryCustom {
+
+    private static final long TOTAL_DEFAULT_VALUE = 0L;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<FranchiseSearchResponse> pageFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable) {
+        List<FranchiseSearchResponse> contents = queryFactory
+                .select(Projections.constructor(FranchiseSearchResponse.class,
+                        franchise.franchiseName, member.name, franchise.franchiseContact, franchise.franchiseAddress,
+                        franchise.franchiseStatus, franchise.contractStartDate, franchise.contractEndDate
+                ))
+                .from(franchise)
+                .leftJoin(member).on(franchise.memberId.eq(member.memberId))
+                .where(
+                        franchiseNameContains(franchiseSearchRequest.franchiseName()),
+                        addressConditions(franchiseSearchRequest),
+                        statusEq(franchiseSearchRequest.franchiseStatus()),
+                        franchiseAgreementDateBetween(
+                                franchiseSearchRequest.contractStartDate(),
+                                franchiseSearchRequest.contractEndDate()
+                        )
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(franchise.contractEndDate.asc())
+                .fetch();
+
+        Long result = queryFactory
+                .select(franchise.count())
+                .from(franchise)
+                .leftJoin(member).on(franchise.memberId.eq(member.memberId))
+                .where(
+                        franchiseNameContains(franchiseSearchRequest.franchiseName()),
+                        addressConditions(franchiseSearchRequest),
+                        statusEq(franchiseSearchRequest.franchiseStatus()),
+                        franchiseAgreementDateBetween(
+                                franchiseSearchRequest.contractStartDate(),
+                                franchiseSearchRequest.contractEndDate()
+                        )
+                )
+                .fetchOne();
+
+        long total = Optional.ofNullable(result).orElse(TOTAL_DEFAULT_VALUE);
+
+        return new PageImpl<>(contents, pageable, total);
+    }
+
+    private BooleanExpression franchiseNameContains(String franchiseName) {
+        return franchiseName != null && !franchiseName.isBlank()
+                ? franchise.franchiseName.contains(franchiseName)
+                : null;
+    }
+
+    private BooleanExpression addressConditions(FranchiseSearchRequest franchiseSearchRequest) {
+        BooleanExpression condition = null;
+
+        if (franchiseSearchRequest.zipcode() != null && !franchiseSearchRequest.zipcode().isBlank()) {
+            condition = safeAnd(condition, franchise.franchiseAddress.zipcode.eq(franchiseSearchRequest.zipcode()));
+        }
+        if (franchiseSearchRequest.addressRoad() != null && !franchiseSearchRequest.addressRoad().isBlank()) {
+            condition = safeAnd(condition, franchise.franchiseAddress.addressRoad.containsIgnoreCase(franchiseSearchRequest.addressRoad()));
+        }
+        if (franchiseSearchRequest.addressDetail() != null && !franchiseSearchRequest.addressDetail().isBlank()) {
+            condition = safeAnd(condition, franchise.franchiseAddress.addressDetail.containsIgnoreCase(franchiseSearchRequest.addressDetail()));
+        }
+
+        return condition;
+    }
+
+    private BooleanExpression safeAnd(BooleanExpression base, BooleanExpression next) {
+        return base == null ? next : base.and(next);
+    }
+
+    private BooleanExpression statusEq(FranchiseStatus status) {
+        return status != null ? franchise.franchiseStatus.eq(status) : null;
+    }
+
+    private BooleanExpression franchiseAgreementDateBetween(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null) {
+            return franchise.contractStartDate.loe(endDate)
+                    .and(franchise.contractEndDate.goe(startDate));
+        } else if (startDate != null) {
+            return franchise.contractStartDate.goe(startDate);
+        } else if (endDate != null) {
+            return franchise.contractEndDate.loe(endDate);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryService.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryService.java
@@ -1,0 +1,12 @@
+package com.harusari.chainware.franchise.query.service;
+
+import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FranchiseQueryService {
+
+    Page<FranchiseSearchResponse> searchFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable);
+
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.harusari.chainware.franchise.query.service;
+
+import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
+import com.harusari.chainware.franchise.query.repository.FranchiseQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FranchiseQueryServiceImpl implements FranchiseQueryService {
+
+    private final FranchiseQueryRepository franchiseQueryRepository;
+
+    @Override
+    public Page<FranchiseSearchResponse> searchFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable) {
+        return franchiseQueryRepository.pageFranchises(franchiseSearchRequest, pageable);
+    }
+
+}


### PR DESCRIPTION
Closes #99 

## 🔥 작업 내용  
- `FranchiseQueryService`에 가맹점 목록 조회 메서드 정의
- QueryDSL을 사용하여 가맹점 목록을 페이징 조회하는 쿼리 작성
- `contract_end_date` 기준 오름차순 정렬 적용
- `PageRequest`를 사용하여 요청 페이지 처리 (크기: 10)
- `FranchiseQueryController`에 조회 API(`/api/v1/franchises`) 구현
- 응답 DTO(`FranchiseListResponse`) 정의 및 매핑 처리
- 인증된 사용자의 권한(Role)에 따라 접근 제어 (General/Senior만 허용)
- 검색 조건(가맹점명, 주소, 가맹점 상태, 계약일)을 통해 목록을 조회하는 기능 구현

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #99 
