### PR TITLE
feat: 가맹점 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -63,6 +63,7 @@ public enum SecurityPolicy {
     /* Franchise */
     FRANCHISE_PUT("/api/v1/franchises/{franchiseId}", PUT, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 정보 수정
     FRANCHISES_GET("/api/v1/franchises", GET, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 목록 조회
+    FRANCHISE_GET("/api/v1/franchises/{franchiseId}", GET, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 상세 조회
 
     /* Vendor */
 

--- a/src/main/java/com/harusari/chainware/franchise/query/controller/FranchiseQueryController.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/controller/FranchiseQueryController.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.franchise.query.controller;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import com.harusari.chainware.franchise.query.service.FranchiseQueryService;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -34,6 +32,17 @@ public class FranchiseQueryController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(pageResponse));
+    }
+
+    @GetMapping("/franchises/{franchiseId}")
+    public ResponseEntity<ApiResponse<FranchiseSearchDetailResponse>> searchFranchise(
+        @PathVariable(name = "franchiseId") Long franchiseId
+    ) {
+        FranchiseSearchDetailResponse franchiseSearchDetailResponse = franchiseQueryService.getFranchiseDetail(franchiseId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(franchiseSearchDetailResponse));
     }
 
 }

--- a/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchiseSearchDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchiseSearchDetailResponse.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.franchise.query.dto.resposne;
+
+import com.harusari.chainware.common.domain.vo.Address;
+import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record FranchiseSearchDetailResponse(
+        Long memberId, String name, String phoneNumber, Long franchiseId, String franchiseName, String franchiseContact,
+        String franchiseTaxId, Address franchiseAddress, String agreementFilePath, String agreementOriginalFileName,
+        Long agreementFileSize, LocalDate contractStartDate, LocalDate contractEndDate, FranchiseStatus franchiseStatus
+) {
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryCustom.java
@@ -1,12 +1,17 @@
 package com.harusari.chainware.franchise.query.repository;
 
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface FranchiseQueryRepositoryCustom {
 
     Page<FranchiseSearchResponse> pageFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable);
+
+    Optional<FranchiseSearchDetailResponse> findFranchiseDetailById(Long franchiseId);
 
 }

--- a/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.franchise.query.repository;
 
 import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus;
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -68,6 +69,22 @@ public class FranchiseQueryRepositoryImpl implements FranchiseQueryRepositoryCus
         long total = Optional.ofNullable(result).orElse(TOTAL_DEFAULT_VALUE);
 
         return new PageImpl<>(contents, pageable, total);
+    }
+
+    @Override
+    public Optional<FranchiseSearchDetailResponse> findFranchiseDetailById(Long franchiseId) {
+        return Optional.ofNullable(queryFactory
+                .select(Projections.constructor(FranchiseSearchDetailResponse.class,
+                        member.memberId, member.name, member.phoneNumber, franchise.franchiseId,
+                        franchise.franchiseName, franchise.franchiseContact, franchise.franchiseTaxId,
+                        franchise.franchiseAddress, franchise.agreementFilePath, franchise.agreementOriginalFileName,
+                        franchise.agreementFileSize, franchise.contractStartDate, franchise.contractEndDate, franchise.franchiseStatus
+                ))
+                .from(franchise)
+                .leftJoin(member).on(franchise.memberId.eq(member.memberId))
+                .where(franchise.franchiseId.eq(franchiseId))
+                .fetchOne()
+        );
     }
 
     private BooleanExpression franchiseNameContains(String franchiseName) {

--- a/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryService.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryService.java
@@ -1,6 +1,7 @@
 package com.harusari.chainware.franchise.query.service;
 
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,5 +9,7 @@ import org.springframework.data.domain.Pageable;
 public interface FranchiseQueryService {
 
     Page<FranchiseSearchResponse> searchFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable);
+
+    FranchiseSearchDetailResponse getFranchiseDetail(Long franchiseId);
 
 }

--- a/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package com.harusari.chainware.franchise.query.service;
 
+import com.harusari.chainware.exception.franchise.FranchiseNotFoundException;
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import com.harusari.chainware.franchise.query.repository.FranchiseQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.harusari.chainware.exception.franchise.FranchiseErrorCode.FRANCHISE_NOT_FOUND_EXCEPTION;
 
 @Service
 @Transactional(readOnly = true)
@@ -19,6 +23,12 @@ public class FranchiseQueryServiceImpl implements FranchiseQueryService {
     @Override
     public Page<FranchiseSearchResponse> searchFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable) {
         return franchiseQueryRepository.pageFranchises(franchiseSearchRequest, pageable);
+    }
+
+    @Override
+    public FranchiseSearchDetailResponse getFranchiseDetail(Long franchiseId) {
+        return franchiseQueryRepository.findFranchiseDetailById(franchiseId)
+                .orElseThrow(() -> new FranchiseNotFoundException(FRANCHISE_NOT_FOUND_EXCEPTION));
     }
 
 }


### PR DESCRIPTION
Closes #101 

## 🔥 작업 내용  
- 가맹점 상세 조회 API 구현
- `SecurityPolicy`에 엔드포인트, `HTTP Method`, 권한 추가
- `FranchiseSearchDetailResponse`에 필요한 필드 추가
- `QueryDSL`로 가맹점 상세 정보 조회하는 쿼리 작성

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #101 
