### PR TITLE
refactor: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -25,6 +25,7 @@ public enum SecurityPolicy {
     MEMBERS_GET("/api/v1/members", GET, ROLE_BASED, List.of(MASTER)), // 회원 정보 조회
     MEMBERS_DETAIL_GET("/api/v1/members/{memberId}", GET, ROLE_BASED, List.of(MASTER)), // 회원 정보 상세 조회
     MEMBERS_PUT("/api/v1/members/{memberId}", PUT, ROLE_BASED, List.of(MASTER)), // 회원 정보 수정
+    MEMBERS_DELETE("/api/v1/members/{memberId}", DELETE, ROLE_BASED, List.of(MASTER)), // 회원 탈퇴
     LOGIN_HISTORY_GET("/api/v1/members/{memberId}/login-history", GET, ROLE_BASED, List.of(MASTER)), // 로그인 내역 조회
 
     // Permit All

--- a/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
@@ -130,4 +130,20 @@ public class MemberCommandController {
                 .body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리합니다. (Soft Delete)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
+    })
+    @DeleteMapping("/members/{memberId}")
+    public ResponseEntity<ApiResponse<Void>> deleteMember(
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId
+    ) {
+        memberCommandService.deleteMemberRequest(memberId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(null));
+    }
+
 }

--- a/src/main/java/com/harusari/chainware/member/command/application/dto/request/UpdateMemberRequest.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/dto/request/UpdateMemberRequest.java
@@ -6,6 +6,6 @@ import lombok.Builder;
 @Builder
 public record UpdateMemberRequest(
         String name, MemberAuthorityType authorityName,
-        String phoneNumber, String position, boolean isDeleted
+        String phoneNumber, String position
 ) {
 }

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
@@ -22,4 +22,6 @@ public interface MemberCommandService {
 
     void updateMemberRequest(Long memberId, UpdateMemberRequest updateMemberRequest);
 
+    void deleteMemberRequest(Long memberId);
+
 }

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
@@ -123,6 +123,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         member.updateMember(authority.getAuthorityId(), updateMemberRequest);
     }
 
+    @Override
+    public void deleteMemberRequest(Long memberId) {
+        Member member = memberCommandRepository.findMemberByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
+
+        member.softDelete();
+    }
+
     private Member registerMember(MemberCreateRequest memberCreateRequest) {
         validateEmailVerification(memberCreateRequest.email(), memberCreateRequest.validationToken());
 

--- a/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
@@ -81,7 +81,11 @@ public class Member {
         this.phoneNumber = updateMemberRequest.phoneNumber();
         this.position = updateMemberRequest.position();
         this.modifiedAt = LocalDateTime.now().withNano(0);
-        this.isDeleted = updateMemberRequest.isDeleted();
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.modifiedAt = LocalDateTime.now().withNano(0);
     }
 
 }

--- a/src/main/java/com/harusari/chainware/member/query/dto/request/MemberSearchRequest.java
+++ b/src/main/java/com/harusari/chainware/member/query/dto/request/MemberSearchRequest.java
@@ -8,6 +8,6 @@ import java.time.LocalDate;
 @Builder
 public record MemberSearchRequest(
         String email, MemberAuthorityType authorityName, String position,
-        LocalDate joinDateFrom, LocalDate joinDateTo, Boolean isDeleted
+        LocalDate joinDateFrom, LocalDate joinDateTo, boolean isDeleted
 ) {
 }


### PR DESCRIPTION
Closes #105 

## 🔥 작업 내용  
- 회원 탈퇴 API 구현
- 존재하는 회원인지 검증하는 로직 구현
- 존재하는 회원이면 `isDeleted` 값을 `true`로 변경 (Soft Delete)
- `SecurityPolicy`에 회원 탈퇴 엔드포인트 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #105 
