### PR TITLE
feat: 재배송 및 신규 배송에 대한 창고 출고 등록

### DIFF
--- a/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartItem.java
+++ b/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartItem.java
@@ -1,0 +1,14 @@
+package com.harusari.chainware.delivery.command.application.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class DeliveryStartItem {
+    private Long productId;
+    private Integer quantity;
+    private LocalDate expirationDate;
+}

--- a/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartItem.java
+++ b/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartItem.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 public class DeliveryStartItem {
-    private Long productId;
-    private Integer quantity;
+    private Long orderDetailId;
+    private Long takeBackDetailId;
     private LocalDate expirationDate;
 }

--- a/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartRequest.java
+++ b/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartRequest.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Builder
 public class DeliveryStartRequest {
 
-    private String trackingNumber;
     private String carrier;
     private List<DeliveryStartItem> products;
 

--- a/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartRequest.java
+++ b/src/main/java/com/harusari/chainware/delivery/command/application/dto/request/DeliveryStartRequest.java
@@ -3,9 +3,15 @@ package com.harusari.chainware.delivery.command.application.dto.request;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Getter
 @Builder
 public class DeliveryStartRequest {
+
     private String trackingNumber;
     private String carrier;
+    private List<DeliveryStartItem> products;
+
 }

--- a/src/main/java/com/harusari/chainware/delivery/command/application/service/DeliveryCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/delivery/command/application/service/DeliveryCommandServiceImpl.java
@@ -55,6 +55,7 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
         Long warehouseId = delivery.getWarehouseId();
         Long orderId = delivery.getOrderId();
         Long takeBackId = delivery.getTakeBackId();
+        String trackingNumber = generateTrackingNumber();
 
         // 4. 배송 대상 제품 및 수량 정보를 저장할 맵 선언
         Map<Long, Integer> productQuantityMap = null;
@@ -122,7 +123,7 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
         }
 
         // 6. 상태 변경
-        delivery.startDelivery(request.getTrackingNumber(), request.getCarrier(), LocalDateTime.now());
+        delivery.startDelivery(trackingNumber, request.getCarrier(), LocalDateTime.now());
 
         return DeliveryCommandResponse.builder()
                 .deliveryId(delivery.getDeliveryId())

--- a/src/main/java/com/harusari/chainware/delivery/command/application/service/DeliveryCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/delivery/command/application/service/DeliveryCommandServiceImpl.java
@@ -10,6 +10,8 @@ import com.harusari.chainware.delivery.exception.DeliveryErrorCode;
 import com.harusari.chainware.delivery.exception.DeliveryException;
 import com.harusari.chainware.order.command.domain.aggregate.OrderDetail;
 import com.harusari.chainware.order.command.domain.repository.OrderDetailRepository;
+import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackDetail;
+import com.harusari.chainware.takeback.command.domain.repository.TakeBackDetailRepository;
 import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseInventory;
 import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseOutbound;
 import com.harusari.chainware.warehouse.command.domain.repository.WarehouseInventoryRepository;
@@ -36,6 +38,7 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
     private final OrderDetailRepository orderDetailRepository;
     private final WarehouseInventoryRepository warehouseInventoryRepository;
     private final WarehouseOutboundRepository warehouseOutboundRepository;
+    private final TakeBackDetailRepository takeBackDetailRepository;
 
     @Override
     public DeliveryCommandResponse startDelivery(Long deliveryId, DeliveryStartRequest request) {
@@ -48,34 +51,51 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
             throw new DeliveryException(DeliveryErrorCode.DELIVERY_STATUS_NOT_REQUESTED);
         }
 
-        // 3. 주문 상세 정보 조회
+        // 3. 배송 기본 정보 추출
+        Long warehouseId = delivery.getWarehouseId();
         Long orderId = delivery.getOrderId();
-        List<OrderDetail> details = orderDetailRepository.findByOrderId(orderId);
-        if (details.isEmpty()) {
-            throw new DeliveryException(DeliveryErrorCode.ORDER_DETAIL_NOT_FOUND_FOR_DELIVERY);
+        Long takeBackId = delivery.getTakeBackId();
+
+        // 4. 배송 대상 제품 및 수량 정보를 저장할 맵 선언
+        Map<Long, Integer> productQuantityMap = null;
+
+        if(takeBackId != null){
+            // 4-1. 재배송 (반품 기반 배송)
+            List<TakeBackDetail> details = takeBackDetailRepository.findByTakeBackId(takeBackId);
+            if (details.isEmpty()) {
+                throw new DeliveryException(DeliveryErrorCode.TAKE_BACK_DETAIL_NOT_FOUND);
+            }
+
+            productQuantityMap = details.stream()
+                    .collect(Collectors.toMap(TakeBackDetail::getProductId, TakeBackDetail::getQuantity));
+
+        } else if (orderId != null){
+            // 4-2. 주문 기반 배송
+            List<OrderDetail> details = orderDetailRepository.findByOrderId(orderId);
+            if (details.isEmpty()) {
+                throw new DeliveryException(DeliveryErrorCode.ORDER_DETAIL_NOT_FOUND_FOR_DELIVERY);
+            }
+
+            productQuantityMap = details.stream()
+                    .collect(Collectors.toMap(OrderDetail::getProductId, OrderDetail::getQuantity));
         }
 
-        // 4. 주문 상세 정보 기반으로 주문한 제품 목록 추출
-        Map<Long, Integer> orderProductMap = details.stream()
-                .collect(Collectors.toMap(OrderDetail::getProductId, OrderDetail::getQuantity));
-
-        // 6. 재고 차감 로직 실행
-        Long warehouseId = delivery.getWarehouseId();
+        // 5. 재고 차감 로직 실행
         for (DeliveryStartItem item : request.getProducts()) {
-            // 6-1. 요청 항목에서 제품 정보 추출
+            // 5-1. 요청 항목에서 제품 정보 추출
             Long productId = item.getProductId();
             Integer quantity = item.getQuantity();
             LocalDate expirationDate = item.getExpirationDate();
 
-            // 6-2. 주문 상세 관련 검증
-            if (!orderProductMap.containsKey(productId)) {
+            // 5-2. 주문 상세 관련 검증
+            if (!productQuantityMap.containsKey(productId)) {
                 throw new DeliveryException(DeliveryErrorCode.PRODUCT_NOT_FOUND_IN_ORDER);
             }
-            if (orderProductMap.get(productId) < quantity) {
+            if (productQuantityMap.get(productId) < quantity) {
                 throw new DeliveryException(DeliveryErrorCode.INVALID_DELIVERY_QUANTITY);
             }
 
-            // 6-3. 창고 재고 조회 및 검증
+            // 5-3. 창고 재고 조회 및 검증
             WarehouseInventory inventory = warehouseInventoryRepository
                     .findByWarehouseIdAndProductIdForUpdate(warehouseId, productId)
                     .orElseThrow(() -> new DeliveryException(DeliveryErrorCode.PRODUCT_INVENTORY_NOT_FOUND_FOR_DELIVERY));
@@ -84,11 +104,11 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
                 throw new DeliveryException(DeliveryErrorCode.INSUFFICIENT_INVENTORY_FOR_DELIVERY);
             }
 
-            // 6-4. 재고 차감
+            // 5-4. 재고 차감
             inventory.decreaseQuantity(quantity, LocalDateTime.now());
             inventory.decreaseReservedQuantity(quantity, LocalDateTime.now());
 
-            // 6-5. 창고 출고 등록
+            // 5-5. 창고 출고 등록
             WarehouseOutbound outbound = WarehouseOutbound.builder()
                     .orderId(orderId)
                     .warehouseId(warehouseId)
@@ -101,7 +121,7 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
             warehouseOutboundRepository.save(outbound);
         }
 
-        // 7. 상태 변경
+        // 6. 상태 변경
         delivery.startDelivery(request.getTrackingNumber(), request.getCarrier(), LocalDateTime.now());
 
         return DeliveryCommandResponse.builder()

--- a/src/main/java/com/harusari/chainware/delivery/command/application/service/DeliveryCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/delivery/command/application/service/DeliveryCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.delivery.command.application.service;
 
+import com.harusari.chainware.delivery.command.application.dto.request.DeliveryStartItem;
 import com.harusari.chainware.delivery.command.application.dto.request.DeliveryStartRequest;
 import com.harusari.chainware.delivery.command.application.dto.response.DeliveryCommandResponse;
 import com.harusari.chainware.delivery.command.domain.aggregate.Delivery;
@@ -10,14 +11,19 @@ import com.harusari.chainware.delivery.exception.DeliveryException;
 import com.harusari.chainware.order.command.domain.aggregate.OrderDetail;
 import com.harusari.chainware.order.command.domain.repository.OrderDetailRepository;
 import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseInventory;
+import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseOutbound;
 import com.harusari.chainware.warehouse.command.domain.repository.WarehouseInventoryRepository;
+import com.harusari.chainware.warehouse.command.domain.repository.WarehouseOutboundRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -29,6 +35,7 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
 
     private final OrderDetailRepository orderDetailRepository;
     private final WarehouseInventoryRepository warehouseInventoryRepository;
+    private final WarehouseOutboundRepository warehouseOutboundRepository;
 
     @Override
     public DeliveryCommandResponse startDelivery(Long deliveryId, DeliveryStartRequest request) {
@@ -48,22 +55,53 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
             throw new DeliveryException(DeliveryErrorCode.ORDER_DETAIL_NOT_FOUND_FOR_DELIVERY);
         }
 
-        // 4. 재고 차감 로직 실행
-        for (OrderDetail detail : details) {
-            WarehouseInventory inventory = warehouseInventoryRepository.findByProductId(detail.getProductId())
+        // 4. 주문 상세 정보 기반으로 주문한 제품 목록 추출
+        Map<Long, Integer> orderProductMap = details.stream()
+                .collect(Collectors.toMap(OrderDetail::getProductId, OrderDetail::getQuantity));
+
+        // 6. 재고 차감 로직 실행
+        Long warehouseId = delivery.getWarehouseId();
+        for (DeliveryStartItem item : request.getProducts()) {
+            // 6-1. 요청 항목에서 제품 정보 추출
+            Long productId = item.getProductId();
+            Integer quantity = item.getQuantity();
+            LocalDate expirationDate = item.getExpirationDate();
+
+            // 6-2. 주문 상세 관련 검증
+            if (!orderProductMap.containsKey(productId)) {
+                throw new DeliveryException(DeliveryErrorCode.PRODUCT_NOT_FOUND_IN_ORDER);
+            }
+            if (orderProductMap.get(productId) < quantity) {
+                throw new DeliveryException(DeliveryErrorCode.INVALID_DELIVERY_QUANTITY);
+            }
+
+            // 6-3. 창고 재고 조회 및 검증
+            WarehouseInventory inventory = warehouseInventoryRepository
+                    .findByWarehouseIdAndProductIdForUpdate(warehouseId, productId)
                     .orElseThrow(() -> new DeliveryException(DeliveryErrorCode.PRODUCT_INVENTORY_NOT_FOUND_FOR_DELIVERY));
 
-            // 수량 차감 처리
-            int quantity = detail.getQuantity();
             if (inventory.getQuantity() < quantity || inventory.getReservedQuantity() < quantity) {
                 throw new DeliveryException(DeliveryErrorCode.INSUFFICIENT_INVENTORY_FOR_DELIVERY);
             }
 
+            // 6-4. 재고 차감
             inventory.decreaseQuantity(quantity, LocalDateTime.now());
             inventory.decreaseReservedQuantity(quantity, LocalDateTime.now());
+
+            // 6-5. 창고 출고 등록
+            WarehouseOutbound outbound = WarehouseOutbound.builder()
+                    .orderId(orderId)
+                    .warehouseId(warehouseId)
+                    .deliveryId(deliveryId)
+                    .productId(productId)
+                    .quantity(quantity)
+                    .expiraionDate(expirationDate)
+                    .build();
+
+            warehouseOutboundRepository.save(outbound);
         }
 
-        // 5. 상태 변경
+        // 7. 상태 변경
         delivery.startDelivery(request.getTrackingNumber(), request.getCarrier(), LocalDateTime.now());
 
         return DeliveryCommandResponse.builder()

--- a/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
@@ -20,7 +20,8 @@ public enum DeliveryErrorCode {
     INSUFFICIENT_INVENTORY_FOR_DELIVERY("10005", "배송할 제품의 수량이 충분하지 않습니다.", HttpStatus.BAD_REQUEST),
     DELIVERY_STATUS_NOT_IN_TRANSIT("10006", "배송 완료 처리는 'IN_TRANSIT' 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_NOT_FOUND_IN_ORDER("10006", "주문에 포함되지 않은 제품입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_DELIVERY_QUANTITY("10006", "배송 불가능한 수량입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_DELIVERY_QUANTITY("10006", "배송 불가능한 수량입니다.", HttpStatus.BAD_REQUEST),
+    TAKE_BACK_DETAIL_NOT_FOUND("10006", "존재하는 반품이 아닙니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
@@ -19,10 +19,10 @@ public enum DeliveryErrorCode {
     PRODUCT_INVENTORY_NOT_FOUND_FOR_DELIVERY("10004", "배송할 제품의 재고 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_INVENTORY_FOR_DELIVERY("10005", "배송할 제품의 수량이 충분하지 않습니다.", HttpStatus.BAD_REQUEST),
     DELIVERY_STATUS_NOT_IN_TRANSIT("10006", "배송 완료 처리는 'IN_TRANSIT' 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
-    PRODUCT_NOT_FOUND_IN_ORDER("10006", "주문에 포함되지 않은 제품입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_DELIVERY_QUANTITY("10006", "배송 불가능한 수량입니다.", HttpStatus.BAD_REQUEST),
-    TAKE_BACK_DETAIL_NOT_FOUND("10006", "존재하는 반품이 아닙니다.", HttpStatus.BAD_REQUEST),
-    INVALID_DELIVERY_DETAIL_ID("10006", "존재하지 않는ㄴ 배송 상세입니다.", HttpStatus.BAD_REQUEST);
+    PRODUCT_NOT_FOUND_IN_ORDER("10007", "주문에 포함되지 않은 제품입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DELIVERY_QUANTITY("10008", "배송 불가능한 수량입니다.", HttpStatus.BAD_REQUEST),
+    TAKE_BACK_DETAIL_NOT_FOUND("10009", "존재하는 반품이 아닙니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DELIVERY_DETAIL_ID("10010", "존재하지 않는 배송 상세입니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
@@ -18,7 +18,9 @@ public enum DeliveryErrorCode {
     ORDER_DETAIL_NOT_FOUND_FOR_DELIVERY("10003", "배송할 주문 상세 정보가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_INVENTORY_NOT_FOUND_FOR_DELIVERY("10004", "배송할 제품의 재고 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_INVENTORY_FOR_DELIVERY("10005", "배송할 제품의 수량이 충분하지 않습니다.", HttpStatus.BAD_REQUEST),
-    DELIVERY_STATUS_NOT_IN_TRANSIT("10006", "배송 완료 처리는 'IN_TRANSIT' 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST);
+    DELIVERY_STATUS_NOT_IN_TRANSIT("10006", "배송 완료 처리는 'IN_TRANSIT' 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
+    PRODUCT_NOT_FOUND_IN_ORDER("10006", "주문에 포함되지 않은 제품입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DELIVERY_QUANTITY("10006", "배송 불가능한 수량입니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/harusari/chainware/delivery/exception/DeliveryErrorCode.java
@@ -21,7 +21,8 @@ public enum DeliveryErrorCode {
     DELIVERY_STATUS_NOT_IN_TRANSIT("10006", "배송 완료 처리는 'IN_TRANSIT' 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_NOT_FOUND_IN_ORDER("10006", "주문에 포함되지 않은 제품입니다.", HttpStatus.BAD_REQUEST),
     INVALID_DELIVERY_QUANTITY("10006", "배송 불가능한 수량입니다.", HttpStatus.BAD_REQUEST),
-    TAKE_BACK_DETAIL_NOT_FOUND("10006", "존재하는 반품이 아닙니다.", HttpStatus.BAD_REQUEST);
+    TAKE_BACK_DETAIL_NOT_FOUND("10006", "존재하는 반품이 아닙니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DELIVERY_DETAIL_ID("10006", "존재하지 않는ㄴ 배송 상세입니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/harusari/chainware/takeback/command/domain/repository/TakeBackDetailRepository.java
+++ b/src/main/java/com/harusari/chainware/takeback/command/domain/repository/TakeBackDetailRepository.java
@@ -3,5 +3,8 @@ package com.harusari.chainware.takeback.command.domain.repository;
 import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TakeBackDetailRepository extends JpaRepository<TakeBackDetail, Long> {
+    List<TakeBackDetail> findByTakeBackId(Long takeBackId);
 }

--- a/src/main/java/com/harusari/chainware/warehouse/command/domain/aggregate/WarehouseOutbound.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/domain/aggregate/WarehouseOutbound.java
@@ -1,0 +1,57 @@
+package com.harusari.chainware.warehouse.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "warehouse_outbound")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WarehouseOutbound {
+
+    @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "outbound_id")
+    private Long outboundId;
+
+    @Column(name = "store_order_id")
+    private Long orderId;
+
+    @Column(name = "warehouse_id")
+    private Long warehouseId;
+
+    @Column(name = "delivery_id")
+    private Long deliveryId;
+
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Column(name = "expiraion_date")
+    private LocalDate expiraionDate;
+
+    @Column(name = "quantity")
+    private Integer quantity;
+
+    @Column(name = "outbounded_at")
+    private LocalDateTime outboundedAt;
+
+    @Builder
+    public WarehouseOutbound(
+            Long orderId, Long warehouseId, Long deliveryId,
+            Long productId, LocalDate expiraionDate, Integer quantity
+    ) {
+        this.orderId = orderId;
+        this.warehouseId = warehouseId;
+        this.deliveryId = deliveryId;
+        this.productId = productId;
+        this.expiraionDate = expiraionDate;
+        this.quantity = quantity;
+        this.outboundedAt = LocalDateTime.now().withNano(0);
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/warehouse/command/domain/repository/WarehouseOutboundRepository.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/domain/repository/WarehouseOutboundRepository.java
@@ -1,0 +1,7 @@
+package com.harusari.chainware.warehouse.command.domain.repository;
+
+import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseOutbound;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WarehouseOutboundRepository extends JpaRepository<WarehouseOutbound, Long> {
+}

--- a/src/test/java/com/harusari/chainware/delivery/command/application/controller/DeliveryCommandControllerTest.java
+++ b/src/test/java/com/harusari/chainware/delivery/command/application/controller/DeliveryCommandControllerTest.java
@@ -56,7 +56,6 @@ class DeliveryCommandControllerTest {
         // given
         DeliveryStartRequest request = DeliveryStartRequest.builder()
                 .carrier("CJ대한통운")
-                .trackingNumber("1234567890")
                 .build();
 
         when(deliveryCommandService.startDelivery(eq(1L), any())).thenReturn(response);
@@ -77,7 +76,6 @@ class DeliveryCommandControllerTest {
         // given
         DeliveryStartRequest request = DeliveryStartRequest.builder()
                 .carrier("CJ대한통운")
-                .trackingNumber("1234567890")
                 .build();
         when(deliveryCommandService.startDelivery(eq(1L), any()))
                 .thenThrow(new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));


### PR DESCRIPTION
Closes #114 

## 🔥 작업 내용  
- 운송장 번호 등록 위치를 사용자 수동 등록에서 시스템에서 제공으로 변경
- 배송 시작 시 주문/재배송 제품 상세 정보에 대한 창고 출고 등록
- 반품 반려의 재배송에 대한 배송의 시작 기능 구현

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #114
