### PR TITLE
feat: 가맹점 계약서 다운로드 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/common/infrastructure/storage/S3Downloader.java
+++ b/src/main/java/com/harusari/chainware/common/infrastructure/storage/S3Downloader.java
@@ -1,0 +1,36 @@
+package com.harusari.chainware.common.infrastructure.storage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class S3Downloader implements StorageDownloader {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    public String generatePresignedUrl(String s3Key, Duration expireAfter) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(expireAfter)
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/common/infrastructure/storage/StorageDownloader.java
+++ b/src/main/java/com/harusari/chainware/common/infrastructure/storage/StorageDownloader.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.common.infrastructure.storage;
+
+import java.time.Duration;
+
+public interface StorageDownloader {
+
+    String generatePresignedUrl(String s3Key, Duration expireAfter);
+
+}

--- a/src/main/java/com/harusari/chainware/config/S3Config.java
+++ b/src/main/java/com/harusari/chainware/config/S3Config.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -24,6 +25,15 @@ public class S3Config {
     public S3Client s3Client() {
         AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
                 .build();

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -65,6 +65,7 @@ public enum SecurityPolicy {
     FRANCHISE_PUT("/api/v1/franchises/{franchiseId}", PUT, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 정보 수정
     FRANCHISES_GET("/api/v1/franchises", GET, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 목록 조회
     FRANCHISE_GET("/api/v1/franchises/{franchiseId}", GET, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 상세 조회
+    FRANCHISE_AGREEMENT_DOWNLOAD_URL("/api/v1/franchises/{franchiseId}/agreement/download", GET, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 가맹점 계약서 다운로드
 
     /* Vendor */
 
@@ -98,7 +99,6 @@ public enum SecurityPolicy {
     /* Delivery */
     DELIVERY_START("/api/v1/delivery/{deliveryId}/start", PUT, ROLE_BASED, List.of(WAREHOUSE_MANAGER)), // 배송 시작
     DELIVERY_COMPLETE("/api/v1/delivery/{deliveryId}/complete", PUT, ROLE_BASED, List.of(FRANCHISE_MANAGER)), // 배송 완료
-
     DELIVERY_LIST_GET("/api/v1/delivery", GET, ROLE_BASED, List.of(FRANCHISE_MANAGER, WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 배송 목록 조회
     DELIVERY_DETAIL_GET("/api/v1/delivery/{deliveryId}", GET, ROLE_BASED, List.of(FRANCHISE_MANAGER, WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 배송 상세 조회
 
@@ -121,10 +121,6 @@ public enum SecurityPolicy {
 
     TAKEBACK_LIST_GET("/api/v1/takeback", GET, ROLE_BASED, List.of(FRANCHISE_MANAGER, WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 반품 목록 조회
     TAKEBACK_DETAIL_GET("/api/v1/takeback/{takebackId}", GET, ROLE_BASED, List.of(FRANCHISE_MANAGER, WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 반품 상세 조회
-
-
-    /* Notification */
-
 
     /* Disposal */
 

--- a/src/main/java/com/harusari/chainware/exception/common/storage/FranchiseAgreementNotFoundException.java
+++ b/src/main/java/com/harusari/chainware/exception/common/storage/FranchiseAgreementNotFoundException.java
@@ -1,0 +1,15 @@
+package com.harusari.chainware.exception.common.storage;
+
+import lombok.Getter;
+
+@Getter
+public class FranchiseAgreementNotFoundException extends RuntimeException {
+
+    private final StorageErrorCode errorCode;
+
+    public FranchiseAgreementNotFoundException(StorageErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/exception/common/storage/StorageErrorCode.java
+++ b/src/main/java/com/harusari/chainware/exception/common/storage/StorageErrorCode.java
@@ -11,7 +11,8 @@ public enum StorageErrorCode {
     FILE_EMPTY("11001", "파일이 비어 있습니다.", HttpStatus.BAD_REQUEST),
     FILE_SIZE_EXCEEDED("11002", "파일 크기는 최대 10MB까지 가능합니다.", HttpStatus.BAD_REQUEST),
     INVALID_FILE_EXTENSION("11003", "허용되지 않은 파일 확장자입니다.", HttpStatus.BAD_REQUEST),
-    S3_UPLOAD_FAILED("11004", "파일 업로드 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    S3_UPLOAD_FAILED("11004", "파일 업로드 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FRANCHISE_AGREEMENT_NOT_FOUND("11005", "해당 가맹점에 등록된 계약서가 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/harusari/chainware/franchise/query/controller/FranchiseQueryController.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/controller/FranchiseQueryController.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.franchise.query.controller;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchisePresignedUrlResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import com.harusari.chainware.franchise.query.service.FranchiseQueryService;
@@ -36,13 +37,24 @@ public class FranchiseQueryController {
 
     @GetMapping("/franchises/{franchiseId}")
     public ResponseEntity<ApiResponse<FranchiseSearchDetailResponse>> searchFranchise(
-        @PathVariable(name = "franchiseId") Long franchiseId
+            @PathVariable(name = "franchiseId") Long franchiseId
     ) {
         FranchiseSearchDetailResponse franchiseSearchDetailResponse = franchiseQueryService.getFranchiseDetail(franchiseId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(franchiseSearchDetailResponse));
+    }
+
+    @GetMapping("/franchises/{franchiseId}/agreement/download")
+    public ResponseEntity<ApiResponse<FranchisePresignedUrlResponse>> getAgreementDownloadUrl(
+            @PathVariable(name = "franchiseId") Long franchiseId
+    ) {
+        FranchisePresignedUrlResponse presignedUrlResponse = franchiseQueryService.generateDownloadUrl(franchiseId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(presignedUrlResponse));
     }
 
 }

--- a/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchisePresignedUrlResponse.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchisePresignedUrlResponse.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.franchise.query.dto.resposne;
+
+import lombok.Builder;
+
+@Builder
+public record FranchisePresignedUrlResponse(
+        String presignedUrl
+) {
+}

--- a/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchiseSearchDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/dto/resposne/FranchiseSearchDetailResponse.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Builder
 public record FranchiseSearchDetailResponse(
         Long memberId, String name, String phoneNumber, Long franchiseId, String franchiseName, String franchiseContact,
-        String franchiseTaxId, Address franchiseAddress, String agreementFilePath, String agreementOriginalFileName,
-        Long agreementFileSize, LocalDate contractStartDate, LocalDate contractEndDate, FranchiseStatus franchiseStatus
+        String franchiseTaxId, Address franchiseAddress, String agreementOriginalFileName, Long agreementFileSize,
+        LocalDate contractStartDate, LocalDate contractEndDate, FranchiseStatus franchiseStatus
 ) {
 }

--- a/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepository.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepository.java
@@ -3,6 +3,10 @@ package com.harusari.chainware.franchise.query.repository;
 import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FranchiseQueryRepository extends FranchiseQueryRepositoryCustom, JpaRepository<Franchise, Long> {
+
+    Optional<Franchise> findFranchiseByFranchiseId(Long franchiseId);
 
 }

--- a/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/repository/FranchiseQueryRepositoryImpl.java
@@ -77,8 +77,8 @@ public class FranchiseQueryRepositoryImpl implements FranchiseQueryRepositoryCus
                 .select(Projections.constructor(FranchiseSearchDetailResponse.class,
                         member.memberId, member.name, member.phoneNumber, franchise.franchiseId,
                         franchise.franchiseName, franchise.franchiseContact, franchise.franchiseTaxId,
-                        franchise.franchiseAddress, franchise.agreementFilePath, franchise.agreementOriginalFileName,
-                        franchise.agreementFileSize, franchise.contractStartDate, franchise.contractEndDate, franchise.franchiseStatus
+                        franchise.franchiseAddress, franchise.agreementOriginalFileName, franchise.agreementFileSize,
+                        franchise.contractStartDate, franchise.contractEndDate, franchise.franchiseStatus
                 ))
                 .from(franchise)
                 .leftJoin(member).on(franchise.memberId.eq(member.memberId))

--- a/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryService.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryService.java
@@ -1,6 +1,7 @@
 package com.harusari.chainware.franchise.query.service;
 
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchisePresignedUrlResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import org.springframework.data.domain.Page;
@@ -11,5 +12,7 @@ public interface FranchiseQueryService {
     Page<FranchiseSearchResponse> searchFranchises(FranchiseSearchRequest franchiseSearchRequest, Pageable pageable);
 
     FranchiseSearchDetailResponse getFranchiseDetail(Long franchiseId);
+
+    FranchisePresignedUrlResponse generateDownloadUrl(Long franchiseId);
 
 }

--- a/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/query/service/FranchiseQueryServiceImpl.java
@@ -1,7 +1,11 @@
 package com.harusari.chainware.franchise.query.service;
 
+import com.harusari.chainware.common.infrastructure.storage.StorageDownloader;
+import com.harusari.chainware.exception.common.storage.FranchiseAgreementNotFoundException;
 import com.harusari.chainware.exception.franchise.FranchiseNotFoundException;
+import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
 import com.harusari.chainware.franchise.query.dto.request.FranchiseSearchRequest;
+import com.harusari.chainware.franchise.query.dto.resposne.FranchisePresignedUrlResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchDetailResponse;
 import com.harusari.chainware.franchise.query.dto.resposne.FranchiseSearchResponse;
 import com.harusari.chainware.franchise.query.repository.FranchiseQueryRepository;
@@ -11,6 +15,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+
+import static com.harusari.chainware.exception.common.storage.StorageErrorCode.FRANCHISE_AGREEMENT_NOT_FOUND;
 import static com.harusari.chainware.exception.franchise.FranchiseErrorCode.FRANCHISE_NOT_FOUND_EXCEPTION;
 
 @Service
@@ -18,6 +25,7 @@ import static com.harusari.chainware.exception.franchise.FranchiseErrorCode.FRAN
 @RequiredArgsConstructor
 public class FranchiseQueryServiceImpl implements FranchiseQueryService {
 
+    private final StorageDownloader s3Downloader;
     private final FranchiseQueryRepository franchiseQueryRepository;
 
     @Override
@@ -29,6 +37,22 @@ public class FranchiseQueryServiceImpl implements FranchiseQueryService {
     public FranchiseSearchDetailResponse getFranchiseDetail(Long franchiseId) {
         return franchiseQueryRepository.findFranchiseDetailById(franchiseId)
                 .orElseThrow(() -> new FranchiseNotFoundException(FRANCHISE_NOT_FOUND_EXCEPTION));
+    }
+
+    @Override
+    public FranchisePresignedUrlResponse generateDownloadUrl(Long franchiseId) {
+        Franchise franchise = franchiseQueryRepository.findFranchiseByFranchiseId(franchiseId)
+                .orElseThrow(() -> new FranchiseNotFoundException(FRANCHISE_NOT_FOUND_EXCEPTION));
+
+        String s3Key = franchise.getAgreementFilePath();
+
+        if (s3Key == null || s3Key.isBlank()) {
+            throw new FranchiseAgreementNotFoundException(FRANCHISE_AGREEMENT_NOT_FOUND);
+        }
+
+        return FranchisePresignedUrlResponse.builder()
+                .presignedUrl(s3Downloader.generatePresignedUrl(s3Key, Duration.ofMinutes(5)))
+                .build();
     }
 
 }


### PR DESCRIPTION
Closes #122 

## 🔥 작업 내용  
- `S3 Presigned URL` 기반 가맹점 계약서 다운로드 기능 구현
- `S3Uploader`, `S3Downloader`에 Presigned URL 발급 기능 추가
- `FranchiseQueryServiceImpl`에 Presigned URL 발급 로직 및 5분 만료 설정
- `FranchiseAgreementQueryController`에 Presigned URL 발급 엔드포인트 생성
- DB `agreement_file_path` 컬럼 기반으로 Presigned URL 발급 연동
- `FranchiseAgreementNotFoundException` 생성 및 예외 의미 명확화

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #122 
