### PR TITLE
refactor: 창고 주소를 우편번호, 도로명 주소, 상세 주소로 세분화

### DIFF
--- a/src/main/java/com/harusari/chainware/member/command/application/dto/request/warehouse/WarehouseCreateRequest.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/dto/request/warehouse/WarehouseCreateRequest.java
@@ -1,9 +1,10 @@
 package com.harusari.chainware.member.command.application.dto.request.warehouse;
 
+import com.harusari.chainware.common.dto.AddressRequest;
 import lombok.Builder;
 
 @Builder
 public record WarehouseCreateRequest(
-        String warehouseName, String warehouseAddress
+        String warehouseName, AddressRequest addressRequest
 ) {
 }

--- a/src/main/java/com/harusari/chainware/vendor/command/application/service/VendorCommandService.java
+++ b/src/main/java/com/harusari/chainware/vendor/command/application/service/VendorCommandService.java
@@ -1,16 +1,14 @@
 package com.harusari.chainware.vendor.command.application.service;
 
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
-import com.harusari.chainware.vendor.command.application.dto.VendorCreateRequestDto;
 import com.harusari.chainware.vendor.command.application.dto.VendorStatusChangeRequestDto;
 import com.harusari.chainware.vendor.command.application.dto.VendorUpdateRequestDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface VendorCommandService {
 
-    Long createVendor(VendorCreateRequestDto requestDto);
+    void createVendorWithAgreement(Long memberId, MemberWithVendorRequest memberWithVendorRequest, MultipartFile agreementFile);
     void updateVendor(Long vendorId, VendorUpdateRequestDto dto);
     void changeVendorStatus(Long vendorId, VendorStatusChangeRequestDto dto);
-    void createVendorWithAgreement(Long memberId, MemberWithVendorRequest memberWithVendorRequest, MultipartFile agreementFile);
 
 }

--- a/src/main/java/com/harusari/chainware/vendor/command/application/service/VendorCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/vendor/command/application/service/VendorCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package com.harusari.chainware.vendor.command.application.service;
 
 import com.harusari.chainware.common.infrastructure.storage.StorageUploader;
+import com.harusari.chainware.franchise.command.domain.aggregate.Franchise;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.vendor.command.application.dto.VendorCreateRequestDto;
 import com.harusari.chainware.vendor.command.application.dto.VendorStatusChangeRequestDto;
@@ -27,22 +28,12 @@ public class VendorCommandServiceImpl implements VendorCommandService {
     private final VendorRepository vendorRepository;
 
     @Override
-    public Long createVendor(VendorCreateRequestDto dto) {
-//        Vendor vendor = Vendor.builder()
-//                .memberId(dto.memberId())
-//                .vendorName(dto.vendorName())
-//                .vendorType(dto.vendorType())
-//                .vendorAddress(dto.vendorAddress())
-//                .vendorTaxId(dto.vendorTaxId())
-//                .vendorMemo(dto.vendorMemo())
-//                .vendorStatus(dto.vendorStatus())
-//                .agreement(dto.agreement())
-//                .vendorStartDate(dto.vendorStartDate())
-//                .vendorEndDate(dto.vendorEndDate())
-//                .build();
-
-//        return vendorRepository.save(vendor).getVendorId();
-        return null;
+    public void createVendorWithAgreement(
+            Long memberId, MemberWithVendorRequest memberWithVendorRequest, MultipartFile agreementFile
+    ) {
+        Vendor vendor = vendorMapStruct.toVendor(memberWithVendorRequest.vendorCreateRequest(), memberId);
+        applyAgreementFileToVendor(agreementFile, vendor);
+        vendorRepository.save(vendor);
     }
 
     @Override
@@ -72,19 +63,12 @@ public class VendorCommandServiceImpl implements VendorCommandService {
         vendorRepository.save(vendor);
     }
 
-    @Override
-    public void createVendorWithAgreement(
-            Long memberId, MemberWithVendorRequest memberWithVendorRequest, MultipartFile agreementFile
-    ) {
-        Vendor vendor = vendorMapStruct.toVendor(memberWithVendorRequest.vendorCreateRequest(), memberId);
+    private void applyAgreementFileToVendor(MultipartFile agreementFile, Vendor vendor) {
         String filePath = s3Uploader.uploadAgreement(agreementFile, VENDOR_DIRECTORY_NAME);
         vendor.updateAgreementInfo(
-                filePath,
-                agreementFile.getOriginalFilename(),
-                agreementFile.getSize(),
-                LocalDateTime.now().withNano(0)
+                filePath, agreementFile.getOriginalFilename(),
+                agreementFile.getSize(), LocalDateTime.now().withNano(0)
         );
-        vendorRepository.save(vendor);
     }
 
 }

--- a/src/main/java/com/harusari/chainware/warehouse/command/application/dto/request/WarehouseUpdateRequest.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/application/dto/request/WarehouseUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.warehouse.command.application.dto.request;
 
+import com.harusari.chainware.common.dto.AddressRequest;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,6 +8,6 @@ import lombok.Getter;
 @Builder
 public class WarehouseUpdateRequest {
     private String warehouseName;
-    private String warehouseAddress;
+    private AddressRequest warehouseAddress;
     private boolean warehouseStatus;
 }

--- a/src/main/java/com/harusari/chainware/warehouse/command/application/dto/response/WarehouseCommandResponse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/application/dto/response/WarehouseCommandResponse.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.warehouse.command.application.dto.response;
 
+import com.harusari.chainware.common.domain.vo.Address;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,6 +9,6 @@ import lombok.Getter;
 public class WarehouseCommandResponse {
     private Long warehouseId;
     private String warehouseName;
-    private String warehouseAddress;
+    private Address warehouseAddress;
     private boolean warehouseStatus;
 }

--- a/src/main/java/com/harusari/chainware/warehouse/command/application/service/WarehouseCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/application/service/WarehouseCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package com.harusari.chainware.warehouse.command.application.service;
 
+import com.harusari.chainware.common.domain.vo.Address;
+import com.harusari.chainware.common.mapstruct.AddressMapStruct;
 import com.harusari.chainware.warehouse.command.application.dto.WarehouseInventoryCommandResponse;
 import com.harusari.chainware.warehouse.command.application.dto.request.WarehouseInventoryCreateRequest;
 import com.harusari.chainware.warehouse.command.application.dto.request.WarehouseInventoryUpdateRequest;
@@ -23,6 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WarehouseCommandServiceImpl implements WarehouseCommandService{
 
+    private final AddressMapStruct addressMapStruct;
     private final WarehouseRepository warehouseRepository;
     private final WarehouseInventoryRepository warehouseInventoryRepository;
 
@@ -33,10 +36,12 @@ public class WarehouseCommandServiceImpl implements WarehouseCommandService{
         Warehouse warehouse = warehouseRepository.findById(warehouseId)
                 .orElseThrow(() -> new WarehouseException(WarehouseErrorCode.WAREHOUSE_NOT_FOUND));
 
+        Address address = addressMapStruct.toAddress(request.getWarehouseAddress());
+
         // 2. 창고 정보 수정
         warehouse.updateInfo(
                 request.getWarehouseName(),
-                request.getWarehouseAddress(),
+                address,
                 request.isWarehouseStatus(),
                 LocalDateTime.now()
         );

--- a/src/main/java/com/harusari/chainware/warehouse/command/domain/aggregate/Warehouse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/domain/aggregate/Warehouse.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.warehouse.command.domain.aggregate;
 
+import com.harusari.chainware.common.domain.vo.Address;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,8 +25,13 @@ public class Warehouse {
     @Column(name = "warehouse_name")
     private String warehouseName;
 
-    @Column(name = "warehouse_address")
-    private String warehouseAddress;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "zipcode", column = @Column(name = "warehouse_zipcode")),
+            @AttributeOverride(name = "addressRoad", column = @Column(name = "warehouse_address_road")),
+            @AttributeOverride(name = "addressDetail", column = @Column(name = "warehouse_address_detail"))
+    })
+    private Address warehouseAddress;
 
     @Column(name = "warehouse_status")
     private boolean warehouseStatus = true;
@@ -41,7 +47,7 @@ public class Warehouse {
 
     @Builder
     public Warehouse(
-            Long memberId, String warehouseName, String warehouseAddress,
+            Long memberId, String warehouseName, Address warehouseAddress,
             boolean warehouseStatus, LocalDateTime modifiedAt, boolean isDeleted
     ) {
         this.memberId = memberId;
@@ -53,9 +59,9 @@ public class Warehouse {
         this.isDeleted = isDeleted;
     }
 
-    public void updateInfo(String name, String address, boolean status, LocalDateTime modifiedAt) {
+    public void updateInfo(String name, Address warehouseAddress, boolean status, LocalDateTime modifiedAt) {
         this.warehouseName = name;
-        this.warehouseAddress = address;
+        this.warehouseAddress = warehouseAddress;
         this.warehouseStatus = status;
         this.modifiedAt = modifiedAt;
     }
@@ -64,6 +70,5 @@ public class Warehouse {
         this.isDeleted = true;
         this.modifiedAt = LocalDateTime.now();
     }
-
 
 }

--- a/src/main/java/com/harusari/chainware/warehouse/common/mapstruct/WarehouseMapStruct.java
+++ b/src/main/java/com/harusari/chainware/warehouse/common/mapstruct/WarehouseMapStruct.java
@@ -1,8 +1,12 @@
 package com.harusari.chainware.warehouse.common.mapstruct;
 
+import com.harusari.chainware.common.domain.vo.Address;
+import com.harusari.chainware.common.dto.AddressRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.WarehouseCreateRequest;
 import com.harusari.chainware.warehouse.command.domain.aggregate.Warehouse;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(
@@ -11,6 +15,23 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface WarehouseMapStruct {
 
+    @Mapping(
+            target = "warehouseAddress",
+            source = "warehouseCreateRequest.addressRequest",
+            qualifiedByName = "addressRequestToAddress"
+    )
     Warehouse toWarehouse(WarehouseCreateRequest warehouseCreateRequest, Long memberId);
+
+    @Named("addressRequestToAddress")
+    default Address addressRequestToAddress(AddressRequest request) {
+        if (request == null) {
+            return null;
+        }
+        return Address.builder()
+                .zipcode(request.zipcode())
+                .addressRoad(request.addressRoad())
+                .addressDetail(request.addressDetail())
+                .build();
+    }
 
 }

--- a/src/test/java/com/harusari/chainware/warehouse/command/application/controller/WarehouseCommandControllerTest.java
+++ b/src/test/java/com/harusari/chainware/warehouse/command/application/controller/WarehouseCommandControllerTest.java
@@ -1,6 +1,8 @@
 package com.harusari.chainware.warehouse.command.application.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.harusari.chainware.common.domain.vo.Address;
+import com.harusari.chainware.common.dto.AddressRequest;
 import com.harusari.chainware.warehouse.command.application.dto.WarehouseInventoryCommandResponse;
 import com.harusari.chainware.warehouse.command.application.dto.request.WarehouseInventoryCreateRequest;
 import com.harusari.chainware.warehouse.command.application.dto.request.WarehouseInventoryUpdateRequest;
@@ -48,22 +50,37 @@ class WarehouseCommandControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    WarehouseUpdateRequest updateRequest;
-    WarehouseCommandResponse warehouseResponse;
-    WarehouseInventoryCommandResponse inventoryResponse;
+    private Address address;
+    private AddressRequest addressRequest;
+
+    private WarehouseUpdateRequest updateRequest;
+    private WarehouseCommandResponse warehouseResponse;
+    private WarehouseInventoryCommandResponse inventoryResponse;
 
     @BeforeEach
     void setUp() {
+        addressRequest = AddressRequest.builder()
+                .zipcode("67890")
+                .addressRoad("New Address")
+                .addressDetail("New Address Detail")
+                .build();
+
+        address = Address.builder()
+                .zipcode("12345")
+                .addressRoad("Updated Address")
+                .addressDetail("Updated Address Detail")
+                .build();
+
         updateRequest = WarehouseUpdateRequest.builder()
                 .warehouseName("Updated Name")
-                .warehouseAddress("Updated Address")
+                .warehouseAddress(addressRequest)
                 .warehouseStatus(true)
                 .build();
 
         warehouseResponse = WarehouseCommandResponse.builder()
                 .warehouseId(1L)
                 .warehouseName("Updated Name")
-                .warehouseAddress("Updated Address")
+                .warehouseAddress(address)
                 .warehouseStatus(true)
                 .build();
 
@@ -95,7 +112,7 @@ class WarehouseCommandControllerTest {
         // given
         WarehouseUpdateRequest request = WarehouseUpdateRequest.builder()
                 .warehouseName("New")
-                .warehouseAddress("New Address")
+                .warehouseAddress(addressRequest)
                 .warehouseStatus(false)
                 .build();
 

--- a/src/test/java/com/harusari/chainware/warehouse/command/application/service/WarehouseCommandServiceImplTest.java
+++ b/src/test/java/com/harusari/chainware/warehouse/command/application/service/WarehouseCommandServiceImplTest.java
@@ -1,5 +1,8 @@
 package com.harusari.chainware.warehouse.command.application.service;
 
+import com.harusari.chainware.common.domain.vo.Address;
+import com.harusari.chainware.common.dto.AddressRequest;
+import com.harusari.chainware.common.mapstruct.AddressMapStruct;
 import com.harusari.chainware.warehouse.command.application.dto.WarehouseInventoryCommandResponse;
 import com.harusari.chainware.warehouse.command.application.dto.request.WarehouseInventoryCreateRequest;
 import com.harusari.chainware.warehouse.command.application.dto.request.WarehouseInventoryUpdateRequest;
@@ -14,6 +17,7 @@ import com.harusari.chainware.warehouse.exception.WarehouseException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import org.mockito.*;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -36,9 +40,27 @@ class WarehouseCommandServiceImplTest {
     @Mock
     private WarehouseInventoryRepository warehouseInventoryRepository;
 
+    @Spy
+    private AddressMapStruct addressMapStruct = Mappers.getMapper(AddressMapStruct.class);;
+
+    private Address address;
+    private AddressRequest addressRequest;
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+
+        address = Address.builder()
+                .zipcode("12345")
+                .addressRoad("Old Address")
+                .addressDetail("Old Address Detail")
+                .build();
+
+        addressRequest = AddressRequest.builder()
+                .zipcode("67890")
+                .addressRoad("New Address")
+                .addressDetail("New Address Detail")
+                .build();
     }
 
     @Test
@@ -47,14 +69,14 @@ class WarehouseCommandServiceImplTest {
         // given
         Warehouse warehouse = Warehouse.builder()
                 .warehouseName("Old")
-                .warehouseAddress("Old Address")
+                .warehouseAddress(address)
                 .warehouseStatus(true)
                 .build();
         ReflectionTestUtils.setField(warehouse, "warehouseId", 1L);
 
         WarehouseUpdateRequest request = WarehouseUpdateRequest.builder()
                 .warehouseName("New")
-                .warehouseAddress("New Address")
+                .warehouseAddress(addressRequest)
                 .warehouseStatus(false)
                 .build();
 
@@ -78,7 +100,7 @@ class WarehouseCommandServiceImplTest {
         assertThatThrownBy(() -> warehouseCommandService.updateWarehouse(1L,
                 WarehouseUpdateRequest.builder()
                         .warehouseName("창고 이름")
-                        .warehouseAddress("창고 주소")
+                        .warehouseAddress(addressRequest)
                         .warehouseStatus(true).build()))
                 .isInstanceOf(WarehouseException.class)
                 .hasFieldOrPropertyWithValue("errorCode", WarehouseErrorCode.WAREHOUSE_NOT_FOUND);
@@ -236,6 +258,5 @@ class WarehouseCommandServiceImplTest {
                 .isInstanceOf(WarehouseException.class)
                 .hasFieldOrPropertyWithValue("errorCode", WarehouseErrorCode.INVENTORY_NOT_FOUND);
     }
-
 
 }


### PR DESCRIPTION
Closes #127 

## 🔥 작업 내용  
- Address VO 내장 타입(Embedded Type) 매핑으로 리팩토링
- 창고 정보 생성 시 주소 필드를 `AddressRequest`으로 수정
- `WarehouseMapStruct`에서 주소 값도 매핑할 수 있도록 코드 수정
- `WarehouseCommandServiceImpl`에서 주소 정보를 업데이트할 때 `AddRequest` 객체를 `Address` vo로 매핑하도록 코드 추가
- `VendorCommandService`에서 사용하지 않은 창고 생성 메서드 삭제
- 관련 테스트 코드 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ⚙️ 특이사항
- 창고 테이블에 우편번호, 도로명 주소, 상세 주소 컬럼 추가
- 노션에 DDL-v35 참고

## ✨ 관련 이슈
- #127 
