### PR TITLE
feat: 재고 관련 조회 기능 구현 및 입고·품의 로직 개선

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -79,6 +79,8 @@ public enum SecurityPolicy {
 
     WAREHOUSE_LIST_GET("/api/v1/warehouse", GET, ROLE_BASED, List.of(WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 창고 마스터 목록 조회
     WAREHOUSE_DETAIL_GET("/api/v1/warehouse/{warehouseId}", GET, ROLE_BASED, List.of(WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 창고 마스터 상세 조회
+    WAREHOUSE_INVENTORY_LIST_GET("/api/v1/warehouse/inventory", GET, ROLE_BASED, List.of(WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 보유 재고 목록 조회
+    WAREHOUSE_INVENTORY_DETAIL_GET("/api/v1/warehouse/inventory/{inventoryId}", GET, ROLE_BASED, List.of(WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 보유 재고 상세 조회
 
     /* Order */
     ORDER_CREATE("/api/v1/orders", POST, ROLE_BASED, List.of(FRANCHISE_MANAGER)), // 주문 등록

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -76,6 +76,9 @@ public enum SecurityPolicy {
     WAREHOUSE_INVENTORY_UPDATE("/api/v1/warehouse/inventory/{inventoryId}", PUT, ROLE_BASED, List.of(WAREHOUSE_MANAGER)), // 보유 재고 수정
     WAREHOUSE_INVENTORY_DELETE("/api/v1/warehouse/inventory/{inventoryId}", PUT, ROLE_BASED, List.of(WAREHOUSE_MANAGER)), // 보유 재고 삭제
 
+    WAREHOUSE_LIST_GET("/api/v1/warehouse", GET, ROLE_BASED, List.of(WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 창고 마스터 목록 조회
+    WAREHOUSE_DETAIL_GET("/api/v1/warehouse/{warehouseId}", GET, ROLE_BASED, List.of(WAREHOUSE_MANAGER, GENERAL_MANAGER, SENIOR_MANAGER)), // 창고 마스터 상세 조회
+
     /* Order */
     ORDER_CREATE("/api/v1/orders", POST, ROLE_BASED, List.of(FRANCHISE_MANAGER)), // 주문 등록
     ORDER_UPDATE("/api/v1/orders/{orderId}", PUT, ROLE_BASED, List.of(FRANCHISE_MANAGER)), // 주문 수정

--- a/src/main/java/com/harusari/chainware/delivery/query/dto/request/DeliverySearchRequest.java
+++ b/src/main/java/com/harusari/chainware/delivery/query/dto/request/DeliverySearchRequest.java
@@ -5,18 +5,20 @@ import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class DeliverySearchRequest {
-    private String franchiseName;                 // 가맹점명 검색
-    private LocalDate startDate;                  // 배송 시작일 필터 (시작)
-    private LocalDate endDate;                    // 배송 시작일 필터 (끝)
-    private DeliveryStatus deliveryStatus;        // 배송 상태 필터
-//    private String warehouseName;                 // 창고명 검색
-//    private String warehouseAddress;              // 창고주소 검색
-//    private WarehouseStatus warehouseStatus;      // 창고 상태 필터 (예: ACTIVE)
+    private String franchiseName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private DeliveryStatus deliveryStatus;
+    private String warehouseName;
+    private String warehouseAddress;
+    private Boolean warehouseStatus;
 }

--- a/src/main/java/com/harusari/chainware/delivery/query/dto/response/DeliveryDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/delivery/query/dto/response/DeliveryDetailResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Builder
 public class DeliveryDetailResponse {
     private DeliveryDetailInfo deliveryInfo;
-//    private WarehouseInfo warehouseInfo;
+    private WarehouseInfo warehouseInfo;
     private FranchiseInfo franchiseInfo;
     private DeliveryOrderInfo orderInfo;
     private List<DeliveryProductInfo> products;

--- a/src/main/java/com/harusari/chainware/delivery/query/dto/response/DeliverySearchResponse.java
+++ b/src/main/java/com/harusari/chainware/delivery/query/dto/response/DeliverySearchResponse.java
@@ -9,13 +9,16 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class DeliverySearchResponse {
-
-    private String trackingNumber;        // 운송장 번호
-//    private String warehouseName;         // 창고명
-    private String franchiseName;         // 가맹점명
-    private String carrier;               // 택배사
-    private String orderCode;             // 배송되는 주문 코드
-    private DeliveryStatus deliveryStatus;// 배송 상태
-    private LocalDateTime startedAt;      // 배송 요청 일시
-    private LocalDateTime deliveredAt;    // 배송 완료 일시
+    private Long deliveryId;
+    private Long orderId;
+    private Long takeBackId;
+    private String trackingNumber;
+    private String warehouseName;
+    private String franchiseName;
+    private String carrier;
+    private String orderCode;
+    private DeliveryStatus deliveryStatus;
+    private LocalDateTime startedAt;
+    private LocalDateTime deliveredAt;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/harusari/chainware/delivery/query/dto/response/FranchiseInfo.java
+++ b/src/main/java/com/harusari/chainware/delivery/query/dto/response/FranchiseInfo.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.delivery.query.dto.response;
 
+import com.harusari.chainware.common.domain.vo.Address;
 import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class FranchiseInfo {
     private String franchiseName;
-    private String franchiseAddress;
+    private Address franchiseAddress;
     private String franchiseTaxId;
     private FranchiseStatus franchiseStatus;
     private String ownerName;

--- a/src/main/java/com/harusari/chainware/delivery/query/dto/response/WarehouseInfo.java
+++ b/src/main/java/com/harusari/chainware/delivery/query/dto/response/WarehouseInfo.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.delivery.query.dto.response;
 
+import com.harusari.chainware.common.domain.vo.Address;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,6 +8,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class WarehouseInfo {
     private String warehouseName;
-    private String warehouseAddress;
+    private Address warehouseAddress;
     private String warehouseManagerName;
 }

--- a/src/main/java/com/harusari/chainware/delivery/query/repository/DeliveryQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/delivery/query/repository/DeliveryQueryRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.harusari.chainware.delivery.query.repository;
 
 import com.harusari.chainware.delivery.query.dto.request.DeliverySearchRequest;
 import com.harusari.chainware.delivery.query.dto.response.*;
-import com.harusari.chainware.order.query.dto.response.OrderProductInfo;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -95,8 +94,14 @@ public class DeliveryQueryRepositoryImpl implements DeliveryQueryRepositoryCusto
         }
 
         if (request.getWarehouseAddress() != null && !request.getWarehouseAddress().isBlank()) {
-            builder.and(warehouse.warehouseAddress.containsIgnoreCase(request.getWarehouseAddress()));
+            String keyword = request.getWarehouseAddress();
+            builder.and(
+                    warehouse.warehouseAddress.zipcode.containsIgnoreCase(keyword)
+                            .or(warehouse.warehouseAddress.addressRoad.containsIgnoreCase(keyword))
+                            .or(warehouse.warehouseAddress.addressDetail.containsIgnoreCase(keyword))
+            );
         }
+
 
         if (request.getWarehouseStatus() != null) {
             builder.and(warehouse.warehouseStatus.eq(request.getWarehouseStatus()));

--- a/src/main/java/com/harusari/chainware/exception/purchase/PurchaseOrderErrorCode.java
+++ b/src/main/java/com/harusari/chainware/exception/purchase/PurchaseOrderErrorCode.java
@@ -18,7 +18,8 @@ public enum PurchaseOrderErrorCode {
     PURCHASE_SHIP_INVALID_STATUS("PO008", "아직 승인되지 않은 발주입니다. 출고 처리 할 수 없습니다.", HttpStatus.BAD_REQUEST),
     PURCHASE_INBOUND_INVALID_STATUS("PO009", "아직 출고 되지 않은 발주입니다. 입고 처리 할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NO_PURCHASE_ORDER_DETAILS("PO010", "발주 품목을 찾을 수 없습니다. 내용을 확인해주세요.", HttpStatus.BAD_REQUEST),
-    EXPIRATION_DATE_REQUIRED("PO011", "유통기한을 반드시 입력해야 합니다.", HttpStatus.BAD_REQUEST);
+    EXPIRATION_DATE_REQUIRED("PO011", "유통기한을 반드시 입력해야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PURCHASE_ORDER_DETAIL_ID("PO012", "발주 상세 항목 ID가 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
 
 
     private final String errorCode;

--- a/src/main/java/com/harusari/chainware/exception/purchase/PurchaseOrderErrorCode.java
+++ b/src/main/java/com/harusari/chainware/exception/purchase/PurchaseOrderErrorCode.java
@@ -17,7 +17,8 @@ public enum PurchaseOrderErrorCode {
     PURCHASE_UPDATE_INVALID_STATUS("PO007", "요청 상태일 때만 수정할 수 있습니다.", HttpStatus.BAD_REQUEST),
     PURCHASE_SHIP_INVALID_STATUS("PO008", "아직 승인되지 않은 발주입니다. 출고 처리 할 수 없습니다.", HttpStatus.BAD_REQUEST),
     PURCHASE_INBOUND_INVALID_STATUS("PO009", "아직 출고 되지 않은 발주입니다. 입고 처리 할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    NO_PURCHASE_ORDER_DETAILS("PO010", "발주 품목을 찾을 수 없습니다. 내용을 확인해주세요.", HttpStatus.BAD_REQUEST);
+    NO_PURCHASE_ORDER_DETAILS("PO010", "발주 품목을 찾을 수 없습니다. 내용을 확인해주세요.", HttpStatus.BAD_REQUEST),
+    EXPIRATION_DATE_REQUIRED("PO011", "유통기한을 반드시 입력해야 합니다.", HttpStatus.BAD_REQUEST);
 
 
     private final String errorCode;

--- a/src/main/java/com/harusari/chainware/purchase/command/application/controller/PurchaseOrderCommandController.java
+++ b/src/main/java/com/harusari/chainware/purchase/command/application/controller/PurchaseOrderCommandController.java
@@ -4,6 +4,7 @@ package com.harusari.chainware.purchase.command.application.controller;
 import com.harusari.chainware.auth.model.CustomUserDetails;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.purchase.command.application.dto.request.CancelPurchaseOrderRequest;
+import com.harusari.chainware.purchase.command.application.dto.request.PurchaseInboundRequest;
 import com.harusari.chainware.purchase.command.application.dto.request.RejectPurchaseOrderRequest;
 import com.harusari.chainware.purchase.command.application.dto.request.UpdatePurchaseOrderRequest;
 import com.harusari.chainware.purchase.command.application.service.PurchaseOrderCommandService;
@@ -106,10 +107,10 @@ public class PurchaseOrderCommandController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "발주 입고 완료")    })
     public ResponseEntity<ApiResponse<Void>> inboundPurchaseOrder(
             @PathVariable Long purchaseOrderId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @ModelAttribute PurchaseInboundRequest request
     ) {
-        purchaseOrderCommandService.inboundPurchaseOrder(purchaseOrderId, userDetails.getMemberId());
+        purchaseOrderCommandService.inboundPurchaseOrder(purchaseOrderId, userDetails.getMemberId(), request);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 

--- a/src/main/java/com/harusari/chainware/purchase/command/application/controller/PurchaseOrderCommandController.java
+++ b/src/main/java/com/harusari/chainware/purchase/command/application/controller/PurchaseOrderCommandController.java
@@ -108,7 +108,7 @@ public class PurchaseOrderCommandController {
     public ResponseEntity<ApiResponse<Void>> inboundPurchaseOrder(
             @PathVariable Long purchaseOrderId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @ModelAttribute PurchaseInboundRequest request
+            @RequestBody PurchaseInboundRequest request
     ) {
         purchaseOrderCommandService.inboundPurchaseOrder(purchaseOrderId, userDetails.getMemberId(), request);
         return ResponseEntity.ok(ApiResponse.success(null));

--- a/src/main/java/com/harusari/chainware/purchase/command/application/dto/request/PurchaseInboundItem.java
+++ b/src/main/java/com/harusari/chainware/purchase/command/application/dto/request/PurchaseInboundItem.java
@@ -1,0 +1,17 @@
+package com.harusari.chainware.purchase.command.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PurchaseInboundItem {
+    private Long purchaseOrderDetailId;
+    private LocalDate expirationDate;
+}

--- a/src/main/java/com/harusari/chainware/purchase/command/application/dto/request/PurchaseInboundRequest.java
+++ b/src/main/java/com/harusari/chainware/purchase/command/application/dto/request/PurchaseInboundRequest.java
@@ -1,0 +1,10 @@
+package com.harusari.chainware.purchase.command.application.dto.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PurchaseInboundRequest {
+    private List<PurchaseInboundItem> products;
+}

--- a/src/main/java/com/harusari/chainware/purchase/command/application/service/PurchaseOrderCommandService.java
+++ b/src/main/java/com/harusari/chainware/purchase/command/application/service/PurchaseOrderCommandService.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.purchase.command.application.service;
 
 import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
 import com.harusari.chainware.purchase.command.application.dto.request.CancelPurchaseOrderRequest;
+import com.harusari.chainware.purchase.command.application.dto.request.PurchaseInboundRequest;
 import com.harusari.chainware.purchase.command.application.dto.request.RejectPurchaseOrderRequest;
 import com.harusari.chainware.purchase.command.application.dto.request.UpdatePurchaseOrderRequest;
 
@@ -20,5 +21,5 @@ public interface PurchaseOrderCommandService {
 
     void shippedPurchaseOrder(Long purchaseOrderId, Long memberId);
 
-    void inboundPurchaseOrder(Long purchaseOrderId, Long memberId);
+    void inboundPurchaseOrder(Long purchaseOrderId, Long memberId, PurchaseInboundRequest request);
 }

--- a/src/main/java/com/harusari/chainware/takeback/query/controller/TakeBackQueryController.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/controller/TakeBackQueryController.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.takeback.query.controller;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackDetailResponse;
 import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
 import com.harusari.chainware.takeback.query.service.TakeBackQueryService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,14 @@ public class TakeBackQueryController {
             @PageableDefault(size = 10, sort = "createdAt") Pageable pageable
     ) {
         PageResponse<TakeBackSearchResponse> response = takeBackQueryService.getTakeBackList(request, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{takeBackId}")
+    public ResponseEntity<ApiResponse<TakeBackDetailResponse>> getTakeBackDetail(
+            @PathVariable Long takeBackId
+    ) {
+        TakeBackDetailResponse response = takeBackQueryService.getTakeBackDetail(takeBackId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/harusari/chainware/takeback/query/controller/TakeBackQueryController.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/controller/TakeBackQueryController.java
@@ -21,6 +21,7 @@ public class TakeBackQueryController {
 
     private final TakeBackQueryService takeBackQueryService;
 
+    // 반품 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<TakeBackSearchResponse>>> getTakeBackList(
             TakeBackSearchRequest request,
@@ -30,6 +31,7 @@ public class TakeBackQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // 반품 상세 조회
     @GetMapping("/{takeBackId}")
     public ResponseEntity<ApiResponse<TakeBackDetailResponse>> getTakeBackDetail(
             @PathVariable Long takeBackId

--- a/src/main/java/com/harusari/chainware/takeback/query/controller/TakeBackQueryController.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/controller/TakeBackQueryController.java
@@ -1,0 +1,32 @@
+package com.harusari.chainware.takeback.query.controller;
+
+import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
+import com.harusari.chainware.takeback.query.service.TakeBackQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/takeback")
+@RequiredArgsConstructor
+public class TakeBackQueryController {
+
+    private final TakeBackQueryService takeBackQueryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<TakeBackSearchResponse>>> getTakeBackList(
+            TakeBackSearchRequest request,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable
+    ) {
+        PageResponse<TakeBackSearchResponse> response = takeBackQueryService.getTakeBackList(request, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/request/TakeBackSearchRequest.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/request/TakeBackSearchRequest.java
@@ -1,0 +1,18 @@
+package com.harusari.chainware.takeback.query.dto.request;
+
+import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class TakeBackSearchRequest {
+    private String warehouseName;
+    private String warehouseAddress;
+    private String franchiseName;
+    private LocalDate fromDate;
+    private LocalDate toDate;
+    private TakeBackStatus takeBackStatus;
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/OrderInfo.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/OrderInfo.java
@@ -1,0 +1,13 @@
+package com.harusari.chainware.takeback.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderInfo {
+    private String orderCode;
+    private int productCount;
+    private int totalQuantity;
+    private long totalPrice;
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackBasicInfo.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackBasicInfo.java
@@ -1,0 +1,17 @@
+package com.harusari.chainware.takeback.query.dto.response;
+
+import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class TakeBackBasicInfo {
+    private String takeBackCode;
+    private TakeBackStatus takeBackStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private String rejectReason;
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackDetailResponse.java
@@ -32,4 +32,5 @@ public class TakeBackDetailResponse {
         this.orderInfo = orderInfo;
         this.productInfos = productInfos;
     }
+
 }

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackDetailResponse.java
@@ -1,0 +1,35 @@
+package com.harusari.chainware.takeback.query.dto.response;
+
+import com.harusari.chainware.delivery.query.dto.response.FranchiseInfo;
+import com.harusari.chainware.delivery.query.dto.response.WarehouseInfo;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.Builder;
+
+import java.util.List;
+
+@Getter
+public class TakeBackDetailResponse {
+
+    private TakeBackBasicInfo takeBackInfo;
+    private FranchiseInfo franchiseInfo;
+    private WarehouseInfo warehouseInfo;
+    private OrderInfo orderInfo;
+    private List<TakeBackProductInfo> productInfos;
+
+    @Builder
+    @QueryProjection
+    public TakeBackDetailResponse(
+            TakeBackBasicInfo takeBackInfo,
+            FranchiseInfo franchiseInfo,
+            WarehouseInfo warehouseInfo,
+            OrderInfo orderInfo,
+            List<TakeBackProductInfo> productInfos
+    ) {
+        this.takeBackInfo = takeBackInfo;
+        this.franchiseInfo = franchiseInfo;
+        this.warehouseInfo = warehouseInfo;
+        this.orderInfo = orderInfo;
+        this.productInfos = productInfos;
+    }
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackProductInfo.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackProductInfo.java
@@ -1,0 +1,36 @@
+package com.harusari.chainware.takeback.query.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class TakeBackProductInfo {
+
+    private Long productId;
+    private String productCode;
+    private String productName;
+    private String unitQuantity;
+    private String unitSpec;
+    private int quantity;
+    private int price;
+    private String takeBackReason;
+    private String takeBackImage;
+
+    @QueryProjection
+    public TakeBackProductInfo(
+            Long productId, String productCode, String productName, String unitQuantity,
+            String unitSpec, int quantity, int price, String takeBackReason, String takeBackImage
+    ) {
+        this.productId = productId;
+        this.productCode = productCode;
+        this.productName = productName;
+        this.unitQuantity = unitQuantity;
+        this.unitSpec = unitSpec;
+        this.quantity = quantity;
+        this.price = price;
+        this.takeBackReason = takeBackReason;
+        this.takeBackImage = takeBackImage;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackProductInfo.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackProductInfo.java
@@ -1,7 +1,6 @@
 package com.harusari.chainware.takeback.query.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackSearchResponse.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackSearchResponse.java
@@ -1,0 +1,41 @@
+package com.harusari.chainware.takeback.query.dto.response;
+
+import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TakeBackSearchResponse {
+    private Long takeBackId;
+    private String takeBackCode;
+    private TakeBackStatus takeBackStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private String warehouseName;
+    private String franchiseName;
+    private String requesterName;
+    private String orderCode;
+    private Long orderId;
+
+    @QueryProjection
+    public TakeBackSearchResponse(
+            Long takeBackId, String takeBackCode, TakeBackStatus takeBackStatus,
+            LocalDateTime createdAt, LocalDateTime modifiedAt,
+            String warehouseName, String franchiseName, String requesterName,
+            String orderCode, Long orderId
+    ) {
+        this.takeBackId = takeBackId;
+        this.takeBackCode = takeBackCode;
+        this.takeBackStatus = takeBackStatus;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.warehouseName = warehouseName;
+        this.franchiseName = franchiseName;
+        this.requesterName = requesterName;
+        this.orderCode = orderCode;
+        this.orderId = orderId;
+    }
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackSearchResponse.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/dto/response/TakeBackSearchResponse.java
@@ -2,13 +2,13 @@ package com.harusari.chainware.takeback.query.dto.response;
 
 import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackStatus;
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class TakeBackSearchResponse {
+
     private Long takeBackId;
     private String takeBackCode;
     private TakeBackStatus takeBackStatus;
@@ -38,4 +38,5 @@ public class TakeBackSearchResponse {
         this.orderCode = orderCode;
         this.orderId = orderId;
     }
+
 }

--- a/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepository.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepository.java
@@ -1,0 +1,7 @@
+package com.harusari.chainware.takeback.query.repository;
+
+import com.harusari.chainware.takeback.command.domain.aggregate.TakeBack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TakeBackQueryRepository extends JpaRepository<TakeBack, Long>, TakeBackQueryRepositoryCustom {
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.harusari.chainware.takeback.query.repository;
+
+import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TakeBackQueryRepositoryCustom {
+    Page<TakeBackSearchResponse> searchTakeBackList(TakeBackSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryCustom.java
@@ -1,10 +1,12 @@
 package com.harusari.chainware.takeback.query.repository;
 
 import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackDetailResponse;
 import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface TakeBackQueryRepositoryCustom {
     Page<TakeBackSearchResponse> searchTakeBackList(TakeBackSearchRequest request, Pageable pageable);
+    TakeBackDetailResponse findTakeBackDetailById(Long takeBackId);
 }

--- a/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryImpl.java
@@ -1,15 +1,12 @@
 package com.harusari.chainware.takeback.query.repository;
 
-import com.harusari.chainware.delivery.command.domain.aggregate.QDelivery;
 import com.harusari.chainware.delivery.query.dto.response.FranchiseInfo;
 import com.harusari.chainware.delivery.query.dto.response.WarehouseInfo;
 import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackStatus;
 import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
 import com.harusari.chainware.takeback.query.dto.response.*;
-import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,7 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,6 +33,7 @@ public class TakeBackQueryRepositoryImpl implements TakeBackQueryRepositoryCusto
 
     private final JPAQueryFactory queryFactory;
 
+    // 반품 목록 조회
     @Override
     public Page<TakeBackSearchResponse> searchTakeBackList(TakeBackSearchRequest request, Pageable pageable) {
         List<TakeBackSearchResponse> contents = queryFactory
@@ -92,10 +89,9 @@ public class TakeBackQueryRepositoryImpl implements TakeBackQueryRepositoryCusto
         return new PageImpl<>(contents, pageable, Optional.ofNullable(total).orElse(0L));
     }
 
+    // 반품 상세 조회
     @Override
     public TakeBackDetailResponse findTakeBackDetailById(Long takeBackId) {
-
-        // 1. 기본 정보 + 조인 정보 조회
         Tuple basic = queryFactory
                 .select(
                         takeBack.takeBackCode,
@@ -130,7 +126,6 @@ public class TakeBackQueryRepositoryImpl implements TakeBackQueryRepositoryCusto
                 .where(takeBack.takeBackId.eq(takeBackId))
                 .fetchOne();
 
-        // 2. 반품 상세 목록 조회
         List<TakeBackProductInfo> productInfos = queryFactory
                 .select(new QTakeBackProductInfo(
                         product.productId,
@@ -148,7 +143,6 @@ public class TakeBackQueryRepositoryImpl implements TakeBackQueryRepositoryCusto
                 .where(takeBackDetail.takeBackId.eq(takeBackId))
                 .fetch();
 
-        // 3. 응답 조립
         TakeBackBasicInfo takeBackInfo = new TakeBackBasicInfo(
                 basic.get(takeBack.takeBackCode),
                 basic.get(takeBack.takeBackStatus),

--- a/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.harusari.chainware.takeback.query.repository;
 
 import com.harusari.chainware.delivery.command.domain.aggregate.QDelivery;
+import com.harusari.chainware.delivery.query.dto.response.FranchiseInfo;
+import com.harusari.chainware.delivery.query.dto.response.WarehouseInfo;
 import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackStatus;
 import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
-import com.harusari.chainware.takeback.query.dto.response.QTakeBackSearchResponse;
-import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
+import com.harusari.chainware.takeback.query.dto.response.*;
 import com.querydsl.core.QueryResults;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -26,7 +28,7 @@ import static com.harusari.chainware.member.command.domain.aggregate.QMember.mem
 import static com.harusari.chainware.order.command.domain.aggregate.QOrder.order;
 import static com.harusari.chainware.takeback.command.domain.aggregate.QTakeBack.takeBack;
 import static com.harusari.chainware.takeback.command.domain.aggregate.QTakeBackDetail.takeBackDetail;
-import static com.harusari.chainware.vendor.command.domain.aggregate.QVendor.vendor;
+import static com.harusari.chainware.product.command.domain.aggregate.QProduct.product;
 import static com.harusari.chainware.warehouse.command.domain.aggregate.QWarehouse.warehouse;
 
 @Repository
@@ -88,6 +90,103 @@ public class TakeBackQueryRepositoryImpl implements TakeBackQueryRepositoryCusto
                 .fetchOne();
 
         return new PageImpl<>(contents, pageable, Optional.ofNullable(total).orElse(0L));
+    }
+
+    @Override
+    public TakeBackDetailResponse findTakeBackDetailById(Long takeBackId) {
+
+        // 1. 기본 정보 + 조인 정보 조회
+        Tuple basic = queryFactory
+                .select(
+                        takeBack.takeBackCode,
+                        takeBack.takeBackStatus,
+                        takeBack.createdAt,
+                        takeBack.modifiedAt,
+                        takeBack.rejectReason,
+
+                        franchise.franchiseName,
+                        franchise.franchiseAddress,
+                        franchise.franchiseContact,
+                        franchise.franchiseStatus,
+                        franchise.franchiseTaxId,
+                        member.name,
+                        member.phoneNumber,
+
+                        warehouse.warehouseName,
+                        warehouse.warehouseAddress,
+                        member.name,
+
+                        order.orderCode,
+                        order.productCount,
+                        order.totalQuantity,
+                        order.totalPrice
+                )
+                .from(takeBack)
+                .join(order).on(order.orderId.eq(takeBack.orderId))
+                .join(franchise).on(franchise.franchiseId.eq(order.franchiseId))
+                .join(member).on(franchise.memberId.eq(member.memberId))
+                .leftJoin(delivery).on(delivery.takeBackId.eq(takeBack.takeBackId))
+                .leftJoin(warehouse).on(warehouse.warehouseId.eq(delivery.warehouseId))
+                .where(takeBack.takeBackId.eq(takeBackId))
+                .fetchOne();
+
+        // 2. 반품 상세 목록 조회
+        List<TakeBackProductInfo> productInfos = queryFactory
+                .select(new QTakeBackProductInfo(
+                        product.productId,
+                        product.productCode,
+                        product.productName,
+                        product.unitQuantity,
+                        product.unitSpec,
+                        takeBackDetail.quantity,
+                        takeBackDetail.price,
+                        takeBackDetail.takeBackReason,
+                        takeBackDetail.takeBackImage
+                ))
+                .from(takeBackDetail)
+                .join(product).on(takeBackDetail.productId.eq(product.productId))
+                .where(takeBackDetail.takeBackId.eq(takeBackId))
+                .fetch();
+
+        // 3. 응답 조립
+        TakeBackBasicInfo takeBackInfo = new TakeBackBasicInfo(
+                basic.get(takeBack.takeBackCode),
+                basic.get(takeBack.takeBackStatus),
+                basic.get(takeBack.createdAt),
+                basic.get(takeBack.modifiedAt),
+                basic.get(takeBack.rejectReason)
+        );
+
+        FranchiseInfo franchiseInfo = new FranchiseInfo(
+                basic.get(franchise.franchiseName),
+                basic.get(franchise.franchiseAddress),
+                basic.get(franchise.franchiseContact),
+                basic.get(franchise.franchiseStatus),
+                basic.get(franchise.franchiseTaxId),
+                basic.get(member.name),
+                basic.get(member.phoneNumber)
+        );
+
+        WarehouseInfo warehouseInfo = new WarehouseInfo(
+                basic.get(warehouse.warehouseName),
+                basic.get(warehouse.warehouseAddress),
+                basic.get(member.name)
+        );
+
+        OrderInfo orderInfo = new OrderInfo(
+                basic.get(order.orderCode),
+                basic.get(order.productCount),
+                basic.get(order.totalQuantity),
+                basic.get(order.totalPrice)
+        );
+
+        return TakeBackDetailResponse.builder()
+                .takeBackInfo(takeBackInfo)
+                .franchiseInfo(franchiseInfo)
+                .warehouseInfo(warehouseInfo)
+                .orderInfo(orderInfo)
+                .productInfos(productInfos)
+                .build();
     }
 
     private BooleanExpression warehouseNameContains(String name) {

--- a/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/repository/TakeBackQueryRepositoryImpl.java
@@ -1,0 +1,121 @@
+package com.harusari.chainware.takeback.query.repository;
+
+import com.harusari.chainware.delivery.command.domain.aggregate.QDelivery;
+import com.harusari.chainware.takeback.command.domain.aggregate.TakeBackStatus;
+import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.QTakeBackSearchResponse;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.harusari.chainware.delivery.command.domain.aggregate.QDelivery.delivery;
+import static com.harusari.chainware.franchise.command.domain.aggregate.QFranchise.franchise;
+import static com.harusari.chainware.member.command.domain.aggregate.QMember.member;
+import static com.harusari.chainware.order.command.domain.aggregate.QOrder.order;
+import static com.harusari.chainware.takeback.command.domain.aggregate.QTakeBack.takeBack;
+import static com.harusari.chainware.takeback.command.domain.aggregate.QTakeBackDetail.takeBackDetail;
+import static com.harusari.chainware.vendor.command.domain.aggregate.QVendor.vendor;
+import static com.harusari.chainware.warehouse.command.domain.aggregate.QWarehouse.warehouse;
+
+@Repository
+@RequiredArgsConstructor
+public class TakeBackQueryRepositoryImpl implements TakeBackQueryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<TakeBackSearchResponse> searchTakeBackList(TakeBackSearchRequest request, Pageable pageable) {
+        List<TakeBackSearchResponse> contents = queryFactory
+                .select(new QTakeBackSearchResponse(
+                        takeBack.takeBackId,
+                        takeBack.takeBackCode,
+                        takeBack.takeBackStatus,
+                        takeBack.createdAt,
+                        takeBack.modifiedAt,
+                        warehouse.warehouseName,
+                        franchise.franchiseName,
+                        member.name,
+                        order.orderCode,
+                        order.orderId
+                ))
+                .from(takeBack)
+                .distinct()
+                .join(order).on(takeBack.orderId.eq(order.orderId))
+                .join(franchise).on(order.franchiseId.eq(franchise.franchiseId))
+                .leftJoin(delivery).on(delivery.takeBackId.eq(takeBack.takeBackId))
+                .leftJoin(warehouse).on(delivery.warehouseId.eq(warehouse.warehouseId))
+                .join(member).on(franchise.memberId.eq(member.memberId))
+                .where(
+                        warehouseNameContains(request.getWarehouseName()),
+                        warehouseAddressContains(request.getWarehouseAddress()),
+                        franchiseNameContains(request.getFranchiseName()),
+                        takeBackStatusEq(request.getTakeBackStatus()),
+                        createdAtBetween(request.getFromDate(), request.getToDate())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(takeBack.createdAt.desc())
+                .fetch();
+
+        Long total = queryFactory
+                .select(takeBack.count())
+                .from(takeBack)
+                .distinct()
+                .join(order).on(takeBack.orderId.eq(order.orderId))
+                .join(franchise).on(order.franchiseId.eq(franchise.franchiseId))
+                .leftJoin(delivery).on(delivery.takeBackId.eq(takeBack.takeBackId))
+                .leftJoin(warehouse).on(delivery.warehouseId.eq(warehouse.warehouseId))
+                .join(member).on(franchise.memberId.eq(member.memberId))
+                .where(
+                        warehouseNameContains(request.getWarehouseName()),
+                        warehouseAddressContains(request.getWarehouseAddress()),
+                        franchiseNameContains(request.getFranchiseName()),
+                        takeBackStatusEq(request.getTakeBackStatus()),
+                        createdAtBetween(request.getFromDate(), request.getToDate())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(contents, pageable, Optional.ofNullable(total).orElse(0L));
+    }
+
+    private BooleanExpression warehouseNameContains(String name) {
+        return (name != null && !name.isBlank()) ? warehouse.warehouseName.containsIgnoreCase(name) : null;
+    }
+
+    private BooleanExpression warehouseAddressContains(String keyword) {
+        if (keyword != null && !keyword.isBlank()) {
+            return warehouse.warehouseAddress.zipcode.containsIgnoreCase(keyword)
+                    .or(warehouse.warehouseAddress.addressRoad.containsIgnoreCase(keyword))
+                    .or(warehouse.warehouseAddress.addressDetail.containsIgnoreCase(keyword));
+        }
+        return null;
+    }
+
+    private BooleanExpression franchiseNameContains(String name) {
+        return (name != null && !name.isBlank()) ? franchise.franchiseName.containsIgnoreCase(name) : null;
+    }
+
+    private BooleanExpression takeBackStatusEq(TakeBackStatus status) {
+        return status != null ? takeBack.takeBackStatus.eq(status) : null;
+    }
+
+    private BooleanExpression createdAtBetween(LocalDate from, LocalDate to) {
+        if (from != null && to != null) return takeBack.createdAt.between(from.atStartOfDay(), to.atStartOfDay());
+        else if (from != null) return takeBack.createdAt.goe(from.atStartOfDay());
+        else if (to != null) return takeBack.createdAt.loe(to.atStartOfDay());
+        return null;
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryService.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryService.java
@@ -1,0 +1,10 @@
+package com.harusari.chainware.takeback.query.service;
+
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface TakeBackQueryService {
+    PageResponse<TakeBackSearchResponse> getTakeBackList(TakeBackSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryService.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryService.java
@@ -2,9 +2,11 @@ package com.harusari.chainware.takeback.query.service;
 
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackDetailResponse;
 import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface TakeBackQueryService {
     PageResponse<TakeBackSearchResponse> getTakeBackList(TakeBackSearchRequest request, Pageable pageable);
+    TakeBackDetailResponse getTakeBackDetail(Long takeBackId);
 }

--- a/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryServiceImpl.java
@@ -1,0 +1,22 @@
+package com.harusari.chainware.takeback.query.service;
+
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
+import com.harusari.chainware.takeback.query.repository.TakeBackQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TakeBackQueryServiceImpl implements TakeBackQueryService {
+    private final TakeBackQueryRepository takeBackQueryRepository;
+
+    @Override
+    public PageResponse<TakeBackSearchResponse> getTakeBackList(TakeBackSearchRequest request, Pageable pageable) {
+        return PageResponse.from(takeBackQueryRepository.searchTakeBackList(request, pageable));
+    }
+}

--- a/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryServiceImpl.java
@@ -14,13 +14,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TakeBackQueryServiceImpl implements TakeBackQueryService {
+
     private final TakeBackQueryRepository takeBackQueryRepository;
 
+    // 반품 목록 조회
     @Override
     public PageResponse<TakeBackSearchResponse> getTakeBackList(TakeBackSearchRequest request, Pageable pageable) {
         return PageResponse.from(takeBackQueryRepository.searchTakeBackList(request, pageable));
     }
 
+    // 반품 상세 조회
     @Override
     public TakeBackDetailResponse getTakeBackDetail(Long takeBackId) {
         return takeBackQueryRepository.findTakeBackDetailById(takeBackId);

--- a/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/takeback/query/service/TakeBackQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.takeback.query.service;
 
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.takeback.query.dto.request.TakeBackSearchRequest;
+import com.harusari.chainware.takeback.query.dto.response.TakeBackDetailResponse;
 import com.harusari.chainware.takeback.query.dto.response.TakeBackSearchResponse;
 import com.harusari.chainware.takeback.query.repository.TakeBackQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,4 +20,10 @@ public class TakeBackQueryServiceImpl implements TakeBackQueryService {
     public PageResponse<TakeBackSearchResponse> getTakeBackList(TakeBackSearchRequest request, Pageable pageable) {
         return PageResponse.from(takeBackQueryRepository.searchTakeBackList(request, pageable));
     }
+
+    @Override
+    public TakeBackDetailResponse getTakeBackDetail(Long takeBackId) {
+        return takeBackQueryRepository.findTakeBackDetailById(takeBackId);
+    }
+
 }

--- a/src/main/java/com/harusari/chainware/vendor/query/dto/VendorDetailDto.java
+++ b/src/main/java/com/harusari/chainware/vendor/query/dto/VendorDetailDto.java
@@ -16,7 +16,9 @@ public class VendorDetailDto {
     private String phoneNumber;
     private String vendorName;
     private VendorType vendorType;
-    private String vendorAddress;
+    private String vendorZipcode;
+    private String vendorAddressRoad;
+    private String vendorAddressDetail;
     private String vendorTaxId;
     private String vendorMemo;
     private VendorStatus vendorStatus;

--- a/src/main/java/com/harusari/chainware/warehouse/command/domain/aggregate/WarehouseInbound.java
+++ b/src/main/java/com/harusari/chainware/warehouse/command/domain/aggregate/WarehouseInbound.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.warehouse.command.domain.aggregate;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -24,17 +25,20 @@ public class WarehouseInbound {
 
     private int unitQuantity;
 
+    private LocalDate expirationDate;
+
     private LocalDateTime inboundedAt;
 
     @Builder
     public WarehouseInbound(Long inboundId, Long purchaseOrderId, Long warehouseId,
-                            Long productId, int unitQuantity, LocalDateTime inboundedAt
+                            Long productId, int unitQuantity, LocalDate expirationDate, LocalDateTime inboundedAt
                          ) {
         this.inboundId = inboundId;
         this.purchaseOrderId = purchaseOrderId;
         this.warehouseId = warehouseId;
         this.productId = productId;
         this.unitQuantity = unitQuantity;
+        this.expirationDate = expirationDate;
         this.inboundedAt = inboundedAt;
     }
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.warehouse.query.controller;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import com.harusari.chainware.warehouse.query.service.WarehouseQueryService;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -33,4 +31,14 @@ public class WarehouseQueryController {
         PageResponse<WarehouseSearchResponse> response = warehouseQueryService.searchWarehouses(request, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
     }
+
+    // 창고 마스터 상세 조회
+    @GetMapping("/{warehouseId}")
+    public ResponseEntity<ApiResponse<WarehouseDetailResponse>> findWarehouseDetail(
+            @PathVariable Long warehouseId
+    ) {
+        WarehouseDetailResponse response = warehouseQueryService.findWarehouseDetailById(warehouseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
@@ -2,8 +2,10 @@ package com.harusari.chainware.warehouse.query.controller;
 
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import com.harusari.chainware.warehouse.query.service.WarehouseQueryService;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,16 @@ public class WarehouseQueryController {
             @PathVariable Long warehouseId
     ) {
         WarehouseDetailResponse response = warehouseQueryService.findWarehouseDetailById(warehouseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 보유 재고 목록 조회
+    @GetMapping("/inventory")
+    public ResponseEntity<ApiResponse<PageResponse<WarehouseInventoryInfo>>> getWarehouseInventories(
+            @ModelAttribute WarehouseInventorySearchRequest request,
+            @PageableDefault(size=10) Pageable pageable
+    ) {
+        PageResponse<WarehouseInventoryInfo> response = warehouseQueryService.getWarehouseInventories(request, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
@@ -5,6 +5,7 @@ import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import com.harusari.chainware.warehouse.query.service.WarehouseQueryService;
@@ -50,6 +51,15 @@ public class WarehouseQueryController {
             @PageableDefault(size=10) Pageable pageable
     ) {
         PageResponse<WarehouseInventoryInfo> response = warehouseQueryService.getWarehouseInventories(request, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 보유 재고 상세 조회
+    @GetMapping("/inventory/{inventoryId}")
+    public ResponseEntity<ApiResponse<WarehouseInventoryDetailResponse>> getWarehouseInventoryDetail(
+            @PathVariable Long inventoryId
+    ) {
+        WarehouseInventoryDetailResponse response = warehouseQueryService.getWarehouseInventoryDetail(inventoryId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/controller/WarehouseQueryController.java
@@ -1,0 +1,36 @@
+package com.harusari.chainware.warehouse.query.controller;
+
+import com.harusari.chainware.common.dto.ApiResponse;
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
+import com.harusari.chainware.warehouse.query.service.WarehouseQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/warehouse")
+@RequiredArgsConstructor
+public class WarehouseQueryController {
+
+    private final WarehouseQueryService warehouseQueryService;
+
+    // 창고 마스터 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<WarehouseSearchResponse>>> searchWarehouses(
+            @ModelAttribute WarehouseSearchRequest request,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        PageResponse<WarehouseSearchResponse> response = warehouseQueryService.searchWarehouses(request, pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/request/WarehouseInventorySearchRequest.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/request/WarehouseInventorySearchRequest.java
@@ -1,0 +1,18 @@
+package com.harusari.chainware.warehouse.query.dto.request;
+
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public class WarehouseInventorySearchRequest {
+    private String warehouseName;
+    private String warehouseAddress;
+    private Boolean warehouseStatus;
+    private String productCode;
+    private String productName;
+    private Long topCategoryId;
+    private Long categoryId;
+    private int page;
+    private int size;
+    private Sort sort;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/request/WarehouseSearchRequest.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/request/WarehouseSearchRequest.java
@@ -1,0 +1,14 @@
+package com.harusari.chainware.warehouse.query.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WarehouseSearchRequest {
+    private String warehouseName;
+    private String warehouseAddress;
+    private Boolean warehouseStatus;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InboundHistory.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InboundHistory.java
@@ -13,6 +13,6 @@ public class InboundHistory {
     private String purchaseOrderCode;
     private Long purchaseOrderId;
     private Integer quantity;
-//    private LocalDate expirationDate;
+    private LocalDate expirationDate;
     private LocalDateTime inboundedAt;
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InboundHistory.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InboundHistory.java
@@ -1,0 +1,18 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class InboundHistory {
+    private String vendorName;
+    private String purchaseOrderCode;
+    private Long purchaseOrderId;
+    private Integer quantity;
+//    private LocalDate expirationDate;
+    private LocalDateTime inboundedAt;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InboundHistoryInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InboundHistoryInfo.java
@@ -1,0 +1,22 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import com.harusari.chainware.purchase.command.domain.aggregate.PurchaseOrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class InboundHistoryInfo {
+    private String vendorName;
+    private String createdBy;
+    private String vendorContact;
+    private LocalDateTime createdAt;
+    private PurchaseOrderStatus purchaseOrderStatus;
+    private Long requisitionId;
+    private String requisitionCode;
+    private int productCount;
+    private int totalQuantity;
+    private long totalPrice;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InventorySimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InventorySimpleInfo.java
@@ -1,11 +1,17 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class InventorySimpleInfo {
     private Integer quantity;
     private Integer reservedQuantity;
+
+    @QueryProjection
+    public InventorySimpleInfo(Integer quantity, Integer reservedQuantity) {
+        this.quantity = quantity;
+        this.reservedQuantity = reservedQuantity;
+    }
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InventorySimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InventorySimpleInfo.java
@@ -1,0 +1,11 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InventorySimpleInfo {
+    private Integer quantity;
+    private Integer reservedQuantity;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InventorySimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/InventorySimpleInfo.java
@@ -1,17 +1,20 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 public class InventorySimpleInfo {
+
     private Integer quantity;
     private Integer reservedQuantity;
 
     @QueryProjection
-    public InventorySimpleInfo(Integer quantity, Integer reservedQuantity) {
+    public InventorySimpleInfo(
+            Integer quantity, Integer reservedQuantity
+    ) {
         this.quantity = quantity;
         this.reservedQuantity = reservedQuantity;
     }
+
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/OutboundHistory.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/OutboundHistory.java
@@ -1,0 +1,19 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import com.harusari.chainware.delivery.command.domain.aggregate.DeliveryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class OutboundHistory {
+    private String trackingNumber;
+    private String carrier;
+    private LocalDateTime requestedAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime deliveredAt;
+    private DeliveryStatus deliveryStatus;
+    private String franchiseName;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/OutboundHistoryInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/OutboundHistoryInfo.java
@@ -1,0 +1,19 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import com.harusari.chainware.delivery.command.domain.aggregate.DeliveryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class OutboundHistoryInfo {
+    private String trackingNumber;
+    private String carrier;
+    private LocalDateTime createdAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime deliveredAt;
+    private DeliveryStatus deliveryStatus;
+    private String franchiseName;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/ProductSimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/ProductSimpleInfo.java
@@ -1,11 +1,11 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
 import com.harusari.chainware.product.command.domain.aggregate.StoreType;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class ProductSimpleInfo {
     private Long productId;
     private String productCode;
@@ -14,4 +14,17 @@ public class ProductSimpleInfo {
     private String categoryName;
     private Integer basePrice;
     private StoreType storeType;
+
+    @QueryProjection
+    public ProductSimpleInfo(Long productId, String productCode, String productName,
+                             String topCategoryName, String categoryName,
+                             Integer basePrice, StoreType storeType) {
+        this.productId = productId;
+        this.productCode = productCode;
+        this.productName = productName;
+        this.topCategoryName = topCategoryName;
+        this.categoryName = categoryName;
+        this.basePrice = basePrice;
+        this.storeType = storeType;
+    }
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/ProductSimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/ProductSimpleInfo.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 @Getter
 public class ProductSimpleInfo {
+
     private Long productId;
     private String productCode;
     private String productName;
@@ -16,9 +17,11 @@ public class ProductSimpleInfo {
     private StoreType storeType;
 
     @QueryProjection
-    public ProductSimpleInfo(Long productId, String productCode, String productName,
-                             String topCategoryName, String categoryName,
-                             Integer basePrice, StoreType storeType) {
+    public ProductSimpleInfo(
+            Long productId, String productCode, String productName,
+            String topCategoryName, String categoryName,
+            Integer basePrice, StoreType storeType
+    ) {
         this.productId = productId;
         this.productCode = productCode;
         this.productName = productName;
@@ -27,4 +30,5 @@ public class ProductSimpleInfo {
         this.basePrice = basePrice;
         this.storeType = storeType;
     }
+
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/ProductSimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/ProductSimpleInfo.java
@@ -1,0 +1,17 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import com.harusari.chainware.product.command.domain.aggregate.StoreType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductSimpleInfo {
+    private Long productId;
+    private String productCode;
+    private String productName;
+    private String topCategoryName;
+    private String categoryName;
+    private Integer basePrice;
+    private StoreType storeType;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseBasicInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseBasicInfo.java
@@ -1,0 +1,18 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class WarehouseBasicInfo {
+    private String warehouseName;
+    private String warehouseAddress;
+    private boolean warehouseStatus;
+    private String managerName;
+    private String managerPhone;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseBasicInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseBasicInfo.java
@@ -1,18 +1,31 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
+import com.harusari.chainware.common.domain.vo.Address;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 public class WarehouseBasicInfo {
     private String warehouseName;
-    private String warehouseAddress;
+    private Address warehouseAddress;
     private boolean warehouseStatus;
     private String managerName;
     private String managerPhone;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    @QueryProjection
+    public WarehouseBasicInfo(String warehouseName, Address warehouseAddress, boolean warehouseStatus,
+                              String managerName, String managerPhone, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.warehouseName = warehouseName;
+        this.warehouseAddress = warehouseAddress;
+        this.warehouseStatus = warehouseStatus;
+        this.managerName = managerName;
+        this.managerPhone = managerPhone;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseBasicInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseBasicInfo.java
@@ -2,13 +2,13 @@ package com.harusari.chainware.warehouse.query.dto.response;
 
 import com.harusari.chainware.common.domain.vo.Address;
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class WarehouseBasicInfo {
+
     private String warehouseName;
     private Address warehouseAddress;
     private boolean warehouseStatus;
@@ -18,8 +18,11 @@ public class WarehouseBasicInfo {
     private LocalDateTime modifiedAt;
 
     @QueryProjection
-    public WarehouseBasicInfo(String warehouseName, Address warehouseAddress, boolean warehouseStatus,
-                              String managerName, String managerPhone, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public WarehouseBasicInfo(
+            String warehouseName, Address warehouseAddress, boolean warehouseStatus,
+            String managerName, String managerPhone,
+            LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
         this.warehouseName = warehouseName;
         this.warehouseAddress = warehouseAddress;
         this.warehouseStatus = warehouseStatus;
@@ -28,4 +31,5 @@ public class WarehouseBasicInfo {
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }
+
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseDetailResponse.java
@@ -1,0 +1,16 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class WarehouseDetailResponse {
+    private WarehouseBasicInfo warehouseInfo;
+    private List<InboundHistoryInfo> inboundHistory;     // 입고 이력
+    private List<OutboundHistoryInfo> outboundHistory;   // 배송 이력
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseDetailResponse.java
@@ -11,6 +11,6 @@ import java.util.List;
 @AllArgsConstructor
 public class WarehouseDetailResponse {
     private WarehouseBasicInfo warehouseInfo;
-    private List<InboundHistoryInfo> inboundHistory;     // 입고 이력
-    private List<OutboundHistoryInfo> outboundHistory;   // 배송 이력
+    private List<InboundHistoryInfo> inboundHistory;
+    private List<OutboundHistoryInfo> outboundHistory;
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryDetailResponse.java
@@ -1,0 +1,16 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class WarehouseInventoryDetailResponse {
+    private WarehouseSimpleInfo warehouse;
+    private ProductSimpleInfo product;
+    private InventorySimpleInfo inventory;
+    private List<InboundHistory> inboundHistories;
+    private List<OutboundHistory> outboundHistories;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryInfo.java
@@ -1,0 +1,23 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class WarehouseInventoryInfo {
+    private Long warehouseInventoryId;
+    private Long warehouseId;
+    private String warehouseName;
+    private Long productId;
+    private String productCode;
+    private String productName;
+    private String unitQuantity;
+    private String unitSpec;
+    private Integer quantity;
+    private Integer reservedQuantity;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryInfo.java
@@ -1,13 +1,13 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class WarehouseInventoryInfo {
+
     private Long warehouseInventoryId;
     private Long warehouseId;
     private String warehouseName;

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseInventoryInfo.java
@@ -1,12 +1,12 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 public class WarehouseInventoryInfo {
     private Long warehouseInventoryId;
     private Long warehouseId;
@@ -20,4 +20,27 @@ public class WarehouseInventoryInfo {
     private Integer reservedQuantity;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    @QueryProjection
+    public WarehouseInventoryInfo(
+            Long warehouseInventoryId, Long warehouseId, String warehouseName,
+            Long productId, String productCode, String productName,
+            String unitQuantity, String unitSpec,
+            Integer quantity, Integer reservedQuantity,
+            LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        this.warehouseInventoryId = warehouseInventoryId;
+        this.warehouseId = warehouseId;
+        this.warehouseName = warehouseName;
+        this.productId = productId;
+        this.productCode = productCode;
+        this.productName = productName;
+        this.unitQuantity = unitQuantity;
+        this.unitSpec = unitSpec;
+        this.quantity = quantity;
+        this.reservedQuantity = reservedQuantity;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSearchResponse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSearchResponse.java
@@ -1,0 +1,18 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class WarehouseSearchResponse {
+    private Long warehouseId;
+    private String warehouseName;
+    private String warehouseAddress;
+    private String managerName;
+    private String managerPhoneNumber;
+    private boolean warehouseStatus;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSearchResponse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSearchResponse.java
@@ -2,13 +2,13 @@ package com.harusari.chainware.warehouse.query.dto.response;
 
 import com.harusari.chainware.common.domain.vo.Address;
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class WarehouseSearchResponse {
+
     private Long warehouseId;
     private String warehouseName;
     private Address warehouseAddress;

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSearchResponse.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSearchResponse.java
@@ -1,18 +1,34 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
+import com.harusari.chainware.common.domain.vo.Address;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 public class WarehouseSearchResponse {
     private Long warehouseId;
     private String warehouseName;
-    private String warehouseAddress;
+    private Address warehouseAddress;
     private String managerName;
     private String managerPhoneNumber;
     private boolean warehouseStatus;
     private LocalDateTime createdAt;
+
+    @QueryProjection
+    public WarehouseSearchResponse(
+            Long warehouseId, String warehouseName, Address warehouseAddress,
+            String managerName, String managerPhoneNumber, boolean warehouseStatus, LocalDateTime createdAt
+    ) {
+        this.warehouseId = warehouseId;
+        this.warehouseName = warehouseName;
+        this.warehouseAddress = warehouseAddress;
+        this.managerName = managerName;
+        this.managerPhoneNumber = managerPhoneNumber;
+        this.warehouseStatus = warehouseStatus;
+        this.createdAt = createdAt;
+    }
+
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSimpleInfo.java
@@ -1,13 +1,22 @@
 package com.harusari.chainware.warehouse.query.dto.response;
 
+import com.harusari.chainware.common.domain.vo.Address;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class WarehouseSimpleInfo {
     private Long warehouseId;
     private String warehouseName;
-    private String warehouseAddress;
+    private Address warehouseAddress;
     private boolean warehouseStatus;
+
+    @QueryProjection
+    public WarehouseSimpleInfo(Long warehouseId, String warehouseName, Address warehouseAddress, boolean warehouseStatus) {
+        this.warehouseId = warehouseId;
+        this.warehouseName = warehouseName;
+        this.warehouseAddress = warehouseAddress;
+        this.warehouseStatus = warehouseStatus;
+    }
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSimpleInfo.java
@@ -1,0 +1,13 @@
+package com.harusari.chainware.warehouse.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WarehouseSimpleInfo {
+    private Long warehouseId;
+    private String warehouseName;
+    private String warehouseAddress;
+    private boolean warehouseStatus;
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSimpleInfo.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/dto/response/WarehouseSimpleInfo.java
@@ -2,11 +2,11 @@ package com.harusari.chainware.warehouse.query.dto.response;
 
 import com.harusari.chainware.common.domain.vo.Address;
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 public class WarehouseSimpleInfo {
+
     private Long warehouseId;
     private String warehouseName;
     private Address warehouseAddress;
@@ -19,4 +19,5 @@ public class WarehouseSimpleInfo {
         this.warehouseAddress = warehouseAddress;
         this.warehouseStatus = warehouseStatus;
     }
+
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepository.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepository.java
@@ -1,0 +1,7 @@
+package com.harusari.chainware.warehouse.query.repository;
+
+import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseInventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WarehouseInventoryQueryRepository extends JpaRepository<WarehouseInventory, Long>, WarehouseInventoryQueryRepositoryCustom {
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryCustom.java
@@ -1,10 +1,12 @@
 package com.harusari.chainware.warehouse.query.repository;
 
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface WarehouseInventoryQueryRepositoryCustom {
     Page<WarehouseInventoryInfo> getWarehouseInventories(WarehouseInventorySearchRequest request, Pageable pageable);
+    WarehouseInventoryDetailResponse findWarehouseInventoryDetail(Long warehouseInventoryId);
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.harusari.chainware.warehouse.query.repository;
+
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface WarehouseInventoryQueryRepositoryCustom {
+    Page<WarehouseInventoryInfo> getWarehouseInventories(WarehouseInventorySearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryImpl.java
@@ -6,8 +6,6 @@ import com.harusari.chainware.warehouse.exception.WarehouseException;
 import com.harusari.chainware.warehouse.exception.WarehouseErrorCode;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.*;
-import com.querydsl.core.Tuple;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -103,7 +101,6 @@ public class WarehouseInventoryQueryRepositoryImpl implements WarehouseInventory
         return new PageImpl<>(contents, pageable, Optional.ofNullable(total).orElse(0L));
     }
 
-
     // 보유 재고 상세 조회
     @Override
     public WarehouseInventoryDetailResponse findWarehouseInventoryDetail(Long warehouseInventoryId) {
@@ -164,7 +161,7 @@ public class WarehouseInventoryQueryRepositoryImpl implements WarehouseInventory
                         purchaseOrder.purchaseOrderCode,
                         purchaseOrder.purchaseOrderId,
                         warehouseInbound.unitQuantity,
-//                        warehouseInbound.expiraionDate,
+                        warehouseInbound.expirationDate,
                         warehouseInbound.inboundedAt
                 ))
                 .from(warehouseInbound)

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseInventoryQueryRepositoryImpl.java
@@ -1,0 +1,141 @@
+package com.harusari.chainware.warehouse.query.repository;
+
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.warehouse.command.domain.aggregate.WarehouseInventory;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.harusari.chainware.category.command.domain.aggregate.QTopCategory.topCategory;
+import static com.harusari.chainware.category.command.domain.aggregate.QCategory.category;
+import static com.harusari.chainware.product.command.domain.aggregate.QProduct.product;
+import static com.harusari.chainware.warehouse.command.domain.aggregate.QWarehouse.warehouse;
+import static com.harusari.chainware.warehouse.command.domain.aggregate.QWarehouseInventory.warehouseInventory;
+
+@Repository
+@RequiredArgsConstructor
+public class WarehouseInventoryQueryRepositoryImpl implements WarehouseInventoryQueryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 보유 재고 목록 조회
+    @Override
+    public Page<WarehouseInventoryInfo> getWarehouseInventories(WarehouseInventorySearchRequest request, Pageable pageable) {
+        List<WarehouseInventoryInfo> contents = queryFactory
+                .select(Projections.constructor(WarehouseInventoryInfo.class,
+                        warehouseInventory.warehouseInventoryId,
+                        warehouse.warehouseId,
+                        warehouse.warehouseName,
+                        product.productId,
+                        product.productCode,
+                        product.productName,
+                        product.unitQuantity,
+                        product.unitSpec,
+                        warehouseInventory.quantity,
+                        warehouseInventory.reservedQuantity,
+                        warehouseInventory.createdAt,
+                        warehouseInventory.modifiedAt
+                ))
+                .from(warehouseInventory)
+                .join(warehouse).on(warehouseInventory.warehouseId.eq(warehouse.warehouseId))
+                .join(product).on(warehouseInventory.productId.eq(product.productId))
+                .join(category).on(product.categoryId.eq(category.categoryId))
+                .join(topCategory).on(category.topCategoryId.eq(topCategory.topCategoryId))
+                .where(
+                        warehouse.isDeleted.isFalse(),
+                        nameContains(request.getWarehouseName()),
+                        addressContains(request.getWarehouseAddress()),
+                        statusEq(request.getWarehouseStatus()),
+                        productCodeContains(request.getProductCode()),
+                        productNameContains(request.getProductName()),
+                        topCategoryEq(request.getTopCategoryId()),
+                        categoryEq(request.getCategoryId())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort()))
+                .fetch();
+
+        Long total = queryFactory
+                .select(warehouseInventory.count())
+                .from(warehouseInventory)
+                .join(warehouse).on(warehouseInventory.warehouseId.eq(warehouse.warehouseId))
+                .join(product).on(warehouseInventory.productId.eq(product.productId))
+                .join(category).on(product.categoryId.eq(category.categoryId))
+                .join(topCategory).on(category.topCategoryId.eq(topCategory.topCategoryId))
+                .where(
+                        warehouse.isDeleted.isFalse(),
+                        nameContains(request.getWarehouseName()),
+                        addressContains(request.getWarehouseAddress()),
+                        statusEq(request.getWarehouseStatus()),
+                        productCodeContains(request.getProductCode()),
+                        productNameContains(request.getProductName()),
+                        topCategoryEq(request.getTopCategoryId()),
+                        categoryEq(request.getCategoryId())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(contents, pageable, Optional.ofNullable(total).orElse(0L));
+    }
+
+    private BooleanExpression nameContains(String name) {
+        return (name != null && !name.isBlank()) ? warehouse.warehouseName.containsIgnoreCase(name) : null;
+    }
+
+    private BooleanExpression addressContains(String address) {
+        return (address != null && !address.isBlank()) ? warehouse.warehouseAddress.containsIgnoreCase(address) : null;
+    }
+
+    private BooleanExpression statusEq(Boolean status) {
+        return (status != null) ? warehouse.warehouseStatus.eq(status) : null;
+    }
+
+    private BooleanExpression productCodeContains(String code) {
+        return (code != null && !code.isBlank()) ? product.productCode.containsIgnoreCase(code) : null;
+    }
+
+    private BooleanExpression productNameContains(String name) {
+        return (name != null && !name.isBlank()) ? product.productName.containsIgnoreCase(name) : null;
+    }
+
+    private BooleanExpression topCategoryEq(Long id) {
+        return (id != null) ? topCategory.topCategoryId.eq(id) : null;
+    }
+
+    private BooleanExpression categoryEq(Long id) {
+        return (id != null) ? category.categoryId.eq(id) : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifier(Sort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        for (Sort.Order order : sort) {
+            PathBuilder<?> entityPath = new PathBuilder<>(WarehouseInventory.class, "warehouseInventory");
+            com.querydsl.core.types.Order direction = order.isAscending()
+                    ? com.querydsl.core.types.Order.ASC
+                    : com.querydsl.core.types.Order.DESC;
+            orders.add(new OrderSpecifier<>(direction, entityPath.getComparable(order.getProperty(), Comparable.class)));
+        }
+
+        if (orders.isEmpty()) {
+            orders.add(new OrderSpecifier<>(com.querydsl.core.types.Order.DESC, warehouseInventory.modifiedAt));
+        }
+
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepository.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepository.java
@@ -1,0 +1,7 @@
+package com.harusari.chainware.warehouse.query.repository;
+
+import com.harusari.chainware.warehouse.command.domain.aggregate.Warehouse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WarehouseQueryRepository extends JpaRepository<Warehouse, Long>, WarehouseQueryRepositoryCustom {
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.harusari.chainware.warehouse.query.repository;
+
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface WarehouseQueryRepositoryCustom {
+    Page<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryCustom.java
@@ -1,10 +1,12 @@
 package com.harusari.chainware.warehouse.query.repository;
 
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface WarehouseQueryRepositoryCustom {
     Page<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable);
+    WarehouseDetailResponse findWarehouseDetailById(Long warehouseId);
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryImpl.java
@@ -1,0 +1,101 @@
+package com.harusari.chainware.warehouse.query.repository;
+
+import com.harusari.chainware.order.command.domain.aggregate.Order;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.harusari.chainware.warehouse.command.domain.aggregate.QWarehouse.warehouse;
+import static com.harusari.chainware.member.command.domain.aggregate.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class WarehouseQueryRepositoryImpl implements WarehouseQueryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable) {
+        List<WarehouseSearchResponse> contents = queryFactory
+                .select(Projections.constructor(WarehouseSearchResponse.class,
+                        warehouse.warehouseId,
+                        warehouse.warehouseName,
+                        warehouse.warehouseAddress,
+                        member.name,
+                        member.phoneNumber,
+                        warehouse.warehouseStatus,
+                        warehouse.createdAt
+                ))
+                .from(warehouse)
+                .join(member).on(warehouse.memberId.eq(member.memberId))
+                .where(
+                        warehouse.isDeleted.isFalse(),
+                        nameContains(request.getWarehouseName()),
+                        addressContains(request.getWarehouseAddress()),
+                        statusEq(request.getWarehouseStatus())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(pageable.getSort()))
+                .fetch();
+
+        Long count = queryFactory
+                .select(warehouse.count())
+                .from(warehouse)
+                .join(member).on(warehouse.memberId.eq(member.memberId))
+                .where(
+                        warehouse.isDeleted.isFalse(),
+                        nameContains(request.getWarehouseName()),
+                        addressContains(request.getWarehouseAddress()),
+                        statusEq(request.getWarehouseStatus())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(contents, pageable, Optional.ofNullable(count).orElse(0L));
+    }
+
+    private BooleanExpression nameContains(String name) {
+        return (name != null && !name.isBlank()) ? warehouse.warehouseName.containsIgnoreCase(name) : null;
+    }
+
+    private BooleanExpression addressContains(String address) {
+        return (address != null && !address.isBlank()) ? warehouse.warehouseAddress.containsIgnoreCase(address) : null;
+    }
+
+    private BooleanExpression statusEq(Boolean status) {
+        return (status != null) ? warehouse.warehouseStatus.eq(status) : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifier(Sort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        for (Sort.Order order : sort) {
+            PathBuilder<?> entityPath = new PathBuilder<>(warehouse.getType(), warehouse.getMetadata());
+
+            com.querydsl.core.types.Order direction = order.isAscending()
+                    ? com.querydsl.core.types.Order.ASC
+                    : com.querydsl.core.types.Order.DESC;
+            orders.add(new OrderSpecifier<>(direction, entityPath.getComparable(order.getProperty(), Comparable.class)));
+        }
+
+        if (orders.isEmpty()) {
+            orders.add(new OrderSpecifier<>(com.querydsl.core.types.Order.DESC, warehouse.createdAt));
+        }
+
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/repository/WarehouseQueryRepositoryImpl.java
@@ -1,11 +1,9 @@
 package com.harusari.chainware.warehouse.query.repository;
 
-import com.harusari.chainware.common.domain.vo.Address;
 import com.harusari.chainware.delivery.command.domain.aggregate.DeliveryMethod;
 import com.harusari.chainware.member.command.domain.aggregate.QMember;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.*;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
@@ -1,0 +1,10 @@
+package com.harusari.chainware.warehouse.query.service;
+
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface WarehouseQueryService {
+    PageResponse<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
@@ -1,12 +1,15 @@
 package com.harusari.chainware.warehouse.query.service;
 
 import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface WarehouseQueryService {
     PageResponse<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable);
     WarehouseDetailResponse findWarehouseDetailById(Long warehouseId);
+    PageResponse<WarehouseInventoryInfo> getWarehouseInventories(WarehouseInventorySearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
@@ -2,9 +2,11 @@ package com.harusari.chainware.warehouse.query.service;
 
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface WarehouseQueryService {
     PageResponse<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable);
+    WarehouseDetailResponse findWarehouseDetailById(Long warehouseId);
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryService.java
@@ -4,6 +4,7 @@ import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,5 @@ public interface WarehouseQueryService {
     PageResponse<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable);
     WarehouseDetailResponse findWarehouseDetailById(Long warehouseId);
     PageResponse<WarehouseInventoryInfo> getWarehouseInventories(WarehouseInventorySearchRequest request, Pageable pageable);
+    WarehouseInventoryDetailResponse getWarehouseInventoryDetail(Long warehouseInventoryId);
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
@@ -1,0 +1,25 @@
+package com.harusari.chainware.warehouse.query.service;
+
+import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
+import com.harusari.chainware.warehouse.query.repository.WarehouseQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WarehouseQueryServiceImpl implements WarehouseQueryService{
+
+    private final WarehouseQueryRepository warehouseQueryRepository;
+
+    // 창고 마스터 목록 조회
+    @Override
+    public PageResponse<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable) {
+        return PageResponse.from(warehouseQueryRepository.searchWarehouses(request, pageable));
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import com.harusari.chainware.warehouse.query.repository.WarehouseInventoryQueryRepository;
@@ -37,6 +38,11 @@ public class WarehouseQueryServiceImpl implements WarehouseQueryService{
     @Override
     public PageResponse<WarehouseInventoryInfo> getWarehouseInventories(WarehouseInventorySearchRequest request, Pageable pageable) {
         return PageResponse.from(warehouseInventoryQueryRepository.getWarehouseInventories(request, pageable));
+    }
+
+    @Override
+    public WarehouseInventoryDetailResponse getWarehouseInventoryDetail(Long warehouseInventoryId) {
+        return warehouseInventoryQueryRepository.findWarehouseInventoryDetail(warehouseInventoryId);
     }
 
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
@@ -40,6 +40,7 @@ public class WarehouseQueryServiceImpl implements WarehouseQueryService{
         return PageResponse.from(warehouseInventoryQueryRepository.getWarehouseInventories(request, pageable));
     }
 
+    // 보유 재고 상세 조회
     @Override
     public WarehouseInventoryDetailResponse getWarehouseInventoryDetail(Long warehouseInventoryId) {
         return warehouseInventoryQueryRepository.findWarehouseInventoryDetail(warehouseInventoryId);

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
@@ -1,9 +1,12 @@
 package com.harusari.chainware.warehouse.query.service;
 
 import com.harusari.chainware.common.dto.PageResponse;
+import com.harusari.chainware.warehouse.query.dto.request.WarehouseInventorySearchRequest;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseInventoryInfo;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
+import com.harusari.chainware.warehouse.query.repository.WarehouseInventoryQueryRepository;
 import com.harusari.chainware.warehouse.query.repository.WarehouseQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WarehouseQueryServiceImpl implements WarehouseQueryService{
 
     private final WarehouseQueryRepository warehouseQueryRepository;
+    private final WarehouseInventoryQueryRepository warehouseInventoryQueryRepository;
 
     // 창고 마스터 목록 조회
     @Override
@@ -27,6 +31,12 @@ public class WarehouseQueryServiceImpl implements WarehouseQueryService{
     @Override
     public WarehouseDetailResponse findWarehouseDetailById(Long warehouseId) {
         return warehouseQueryRepository.findWarehouseDetailById(warehouseId);
+    }
+
+    // 보유 재고 목록 조회
+    @Override
+    public PageResponse<WarehouseInventoryInfo> getWarehouseInventories(WarehouseInventorySearchRequest request, Pageable pageable) {
+        return PageResponse.from(warehouseInventoryQueryRepository.getWarehouseInventories(request, pageable));
     }
 
 }

--- a/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/warehouse/query/service/WarehouseQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.harusari.chainware.warehouse.query.service;
 
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.warehouse.query.dto.request.WarehouseSearchRequest;
+import com.harusari.chainware.warehouse.query.dto.response.WarehouseDetailResponse;
 import com.harusari.chainware.warehouse.query.dto.response.WarehouseSearchResponse;
 import com.harusari.chainware.warehouse.query.repository.WarehouseQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,12 @@ public class WarehouseQueryServiceImpl implements WarehouseQueryService{
     @Override
     public PageResponse<WarehouseSearchResponse> searchWarehouses(WarehouseSearchRequest request, Pageable pageable) {
         return PageResponse.from(warehouseQueryRepository.searchWarehouses(request, pageable));
+    }
+
+    // 창고 마스터 상세 조회
+    @Override
+    public WarehouseDetailResponse findWarehouseDetailById(Long warehouseId) {
+        return warehouseQueryRepository.findWarehouseDetailById(warehouseId);
     }
 
 }

--- a/src/main/resources/mappers/vendor/VendorQueryMapper.xml
+++ b/src/main/resources/mappers/vendor/VendorQueryMapper.xml
@@ -74,7 +74,9 @@
         <result property="phoneNumber" column="member_phone"/>
         <result property="vendorName" column="vendor_name"/>
         <result property="vendorType" column="vendor_type" javaType="com.harusari.chainware.vendor.command.domain.aggregate.VendorType"/>
-        <result property="vendorAddress" column="vendor_address"/>
+        <result property="vendorZipcode" column="vendor_zipcode"/>
+        <result property="vendorAddressRoad" column="vendor_address_road"/>
+        <result property="vendorAddressDetail" column="vendor_address_detail"/>
         <result property="vendorTaxId" column="vendor_tax_id"/>
         <result property="vendorMemo" column="vendor_memo"/>
         <result property="vendorStatus" column="vendor_status" javaType="com.harusari.chainware.vendor.command.domain.aggregate.VendorStatus"/>
@@ -92,7 +94,9 @@
         v.vendor_name,
 <!--        v.vendor_contact,-->
         v.vendor_type,
-        v.vendor_address,
+        v.vendor_zipcode,
+        v.vendor_address_road,
+        v.vendor_address_detail,
         v.vendor_tax_id,
         v.vendor_memo,
         v.vendor_status,


### PR DESCRIPTION
Closes #123, Closes #131

## 🔥 작업 내용  
- 창고/배송/반품의 목록 및 상세 조회 기능 구현
- 품의 승인 시 가맹점 주소값 저장값 변경에 따른 mapper 변경
- 발주 입고 시 각 제품에 대한 유통기한 입력

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #123, #131
