### PR TITLE
feat: 회원 개인의 정보 조회, 수정 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/auth/model/CustomUserDetails.java
+++ b/src/main/java/com/harusari/chainware/auth/model/CustomUserDetails.java
@@ -1,10 +1,10 @@
 package com.harusari.chainware.auth.model;
 
-import com.harusari.chainware.member.command.domain.aggregate.Member;
 import com.harusari.chainware.member.command.domain.aggregate.MemberAuthorityType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -20,7 +20,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(memberAuthorityType::name);
+        return List.of(new SimpleGrantedAuthority(memberAuthorityType.name()));
     }
 
     @Override

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -16,6 +16,16 @@ import static org.springframework.http.HttpMethod.*;
 public enum SecurityPolicy {
 
     /* Member */
+    // Permit All
+    LOGIN_POST("/api/v1/auth/login", POST, PERMIT_ALL, List.of()), // 로그인
+    REFRESH_POST("/api/v1/auth/refresh", POST, PERMIT_ALL, List.of()), // 리프레시 토큰 재발급
+
+    // Authenticated
+    LOGOUT_POST("/api/v1/auth/logout", POST, AUTHENTICATED, List.of()), // 로그아웃
+    PASSWORD_POST("/api/v1/auth/password", POST, AUTHENTICATED, List.of()), // 비밀번호 변경
+    MEMBERS_ME_GET("/api/v1/members/me", GET, AUTHENTICATED, List.of()), // 회원 정보 조회
+    MEMBERS_ME_PUT("/api/v1/members/me", PUT, AUTHENTICATED, List.of()), // 회원 정보 수정
+
     // Role Based
     EMAIL_EXISTS_GET("/api/v1/members/email-exists", GET, ROLE_BASED, List.of(MASTER)), // 이메일 중복 확인
     MEMBER_HEADQUARTERS_POST("/api/v1/members/headquarters", POST, ROLE_BASED, List.of(MASTER)), // 본사 직원 회원가입
@@ -27,14 +37,6 @@ public enum SecurityPolicy {
     MEMBERS_PUT("/api/v1/members/{memberId}", PUT, ROLE_BASED, List.of(MASTER)), // 회원 정보 수정
     MEMBERS_DELETE("/api/v1/members/{memberId}", DELETE, ROLE_BASED, List.of(MASTER)), // 회원 탈퇴
     LOGIN_HISTORY_GET("/api/v1/members/{memberId}/login-history", GET, ROLE_BASED, List.of(MASTER)), // 로그인 내역 조회
-
-    // Permit All
-    LOGIN_POST("/api/v1/auth/login", POST, PERMIT_ALL, List.of()), // 로그인
-    REFRESH_POST("/api/v1/auth/refresh", POST, PERMIT_ALL, List.of()), // 리프레시 토큰 재발급
-
-    // Authenticated
-    LOGOUT_POST("/api/v1/auth/logout", POST, AUTHENTICATED, List.of()), // 로그아웃
-    PASSWORD_POST("/api/v1/auth/password", POST, AUTHENTICATED, List.of()), // 비밀번호 변경
 
     /* Category */
     CATEGORY_POST("/api/v1/category", POST, ROLE_BASED, List.of(GENERAL_MANAGER, SENIOR_MANAGER)), // 카테고리 등록
@@ -120,7 +122,6 @@ public enum SecurityPolicy {
     PURCHASE_REJECT_PUT("/api/v1/purchases/{purchaseOrderId}/reject", PUT, ROLE_BASED, List.of(VENDOR_MANAGER)), // 발주 거절
     PURCHASE_SHIPPED_PUT("/api/v1/purchases/{purchaseOrderId}/shipped", PUT, ROLE_BASED, List.of(VENDOR_MANAGER)), // 출고 완료 처리
     PURCHASE_PURCHASE_INBOUND("/api/v1/purchases/{purchaseOrderId}/inbound", PUT, ROLE_BASED, List.of(WAREHOUSE_MANAGER)), // 입고 완료 처리
-
 
     /* Take Back */
     TAKEBACK_REGISTER("/api/v1/takeback", POST, ROLE_BASED, List.of(FRANCHISE_MANAGER)), // 반품 신청

--- a/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/controller/MemberCommandController.java
@@ -4,6 +4,7 @@ import com.harusari.chainware.auth.model.CustomUserDetails;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
+import com.harusari.chainware.member.command.application.dto.request.UpdateMyInfoRequest;
 import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
@@ -112,7 +113,7 @@ public class MemberCommandController {
                 .body(ApiResponse.success(null));
     }
 
-    @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
+    @Operation(summary = "회원 정보 수정 [마스터]", description = "회원 정보를 수정합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 수정 성공")
     })
@@ -123,7 +124,25 @@ public class MemberCommandController {
             @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "회원 수정 요청")
             @RequestBody UpdateMemberRequest updateMemberRequest
     ) {
-        memberCommandService.updateMemberRequest(memberId, updateMemberRequest);
+        memberCommandService.updateMemberInfo(memberId, updateMemberRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "회원 정보 수정 [회원 본인]", description = "회원 정보를 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 수정 성공")
+    })
+    @PutMapping("/members/me")
+    public ResponseEntity<ApiResponse<Void>> updateMyInfo(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "회원 수정 요청")
+            @RequestBody UpdateMyInfoRequest updateMyInfoRequest,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getMemberId();
+        memberCommandService.updateMyInfo(memberId, updateMyInfoRequest);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/harusari/chainware/member/command/application/dto/request/UpdateMyInfoRequest.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/dto/request/UpdateMyInfoRequest.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.member.command.application.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateMyInfoRequest(
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandService.java
@@ -3,6 +3,7 @@ package com.harusari.chainware.member.command.application.service;
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
 import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
+import com.harusari.chainware.member.command.application.dto.request.UpdateMyInfoRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
@@ -20,7 +21,9 @@ public interface MemberCommandService {
 
     void changePassword(PasswordChangeRequest passwordChangeRequest, String email);
 
-    void updateMemberRequest(Long memberId, UpdateMemberRequest updateMemberRequest);
+    void updateMemberInfo(Long memberId, UpdateMemberRequest updateMemberRequest);
+
+    void updateMyInfo(Long memberId, UpdateMyInfoRequest updateMyInfoRequest);
 
     void deleteMemberRequest(Long memberId);
 

--- a/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/command/application/service/MemberCommandServiceImpl.java
@@ -6,6 +6,7 @@ import com.harusari.chainware.franchise.command.application.service.FranchiseCom
 import com.harusari.chainware.member.command.application.dto.request.MemberCreateRequest;
 import com.harusari.chainware.member.command.application.dto.request.PasswordChangeRequest;
 import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
+import com.harusari.chainware.member.command.application.dto.request.UpdateMyInfoRequest;
 import com.harusari.chainware.member.command.application.dto.request.franchise.MemberWithFranchiseRequest;
 import com.harusari.chainware.member.command.application.dto.request.vendor.MemberWithVendorRequest;
 import com.harusari.chainware.member.command.application.dto.request.warehouse.MemberWithWarehouseRequest;
@@ -58,7 +59,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             registerMember(memberCreateRequest);
             deleteEmailVerificationToken(memberCreateRequest.validationToken());
         } else {
-            throw new InvalidMemberAuthorityException(MemberErrorCode.INVALID_MEMBER_AUTHORITY);
+            throw new InvalidMemberAuthorityException(INVALID_MEMBER_AUTHORITY);
         }
     }
 
@@ -71,7 +72,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             franchiseCommandService.createFranchiseWithAgreement(member.getMemberId(), memberWithFranchiseRequest, agreementFile);
             deleteEmailVerificationToken(memberCreateRequest.validationToken());
         } else {
-            throw new InvalidMemberAuthorityException(MemberErrorCode.INVALID_MEMBER_AUTHORITY);
+            throw new InvalidMemberAuthorityException(INVALID_MEMBER_AUTHORITY);
         }
     }
 
@@ -84,7 +85,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             vendorCommandService.createVendorWithAgreement(member.getMemberId(), memberWithVendorRequest, agreementFile);
             deleteEmailVerificationToken(memberCreateRequest.validationToken());
         } else {
-            throw new InvalidMemberAuthorityException(MemberErrorCode.INVALID_MEMBER_AUTHORITY);
+            throw new InvalidMemberAuthorityException(INVALID_MEMBER_AUTHORITY);
         }
     }
 
@@ -98,7 +99,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             warehouseRepository.save(warehouse);
             deleteEmailVerificationToken(memberCreateRequest.validationToken());
         } else {
-            throw new InvalidMemberAuthorityException(MemberErrorCode.INVALID_MEMBER_AUTHORITY);
+            throw new InvalidMemberAuthorityException(INVALID_MEMBER_AUTHORITY);
         }
     }
 
@@ -114,13 +115,21 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public void updateMemberRequest(Long memberId, UpdateMemberRequest updateMemberRequest) {
+    public void updateMemberInfo(Long memberId, UpdateMemberRequest updateMemberRequest) {
         Member member = memberCommandRepository.findMemberByMemberId(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
 
         Authority authority = authorityCommandRepository.findByAuthorityName(updateMemberRequest.authorityName());
 
         member.updateMember(authority.getAuthorityId(), updateMemberRequest);
+    }
+
+    @Override
+    public void updateMyInfo(Long memberId, UpdateMyInfoRequest updateMyInfoRequest) {
+        Member member = memberCommandRepository.findMemberByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
+
+        member.updateMyInfo(updateMyInfoRequest);
     }
 
     @Override
@@ -135,7 +144,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         validateEmailVerification(memberCreateRequest.email(), memberCreateRequest.validationToken());
 
         if (memberCommandRepository.existsByEmail(memberCreateRequest.email())) {
-            throw new EmailAlreadyExistsException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+            throw new EmailAlreadyExistsException(EMAIL_ALREADY_EXISTS);
         }
 
         Member member = memberMapStruct.toMember(memberCreateRequest);
@@ -154,7 +163,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         String emailInRedis = redisTemplate.opsForValue().get(redisKey);
 
         if (emailInRedis == null || !emailInRedis.equals(email)) {
-            throw new EmailVerificationRequiredException(MemberErrorCode.EMAIL_VERIFICATION_REQUIRED);
+            throw new EmailVerificationRequiredException(EMAIL_VERIFICATION_REQUIRED);
         }
     }
 

--- a/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
+++ b/src/main/java/com/harusari/chainware/member/command/domain/aggregate/Member.java
@@ -1,6 +1,7 @@
 package com.harusari.chainware.member.command.domain.aggregate;
 
 import com.harusari.chainware.member.command.application.dto.request.UpdateMemberRequest;
+import com.harusari.chainware.member.command.application.dto.request.UpdateMyInfoRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -81,6 +82,10 @@ public class Member {
         this.phoneNumber = updateMemberRequest.phoneNumber();
         this.position = updateMemberRequest.position();
         this.modifiedAt = LocalDateTime.now().withNano(0);
+    }
+
+    public void updateMyInfo(UpdateMyInfoRequest updateMyInfoRequest) {
+        this.phoneNumber = updateMyInfoRequest.phoneNumber();
     }
 
     public void softDelete() {

--- a/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/harusari/chainware/member/query/controller/MemberQueryController.java
@@ -1,5 +1,6 @@
 package com.harusari.chainware.member.query.controller;
 
+import com.harusari.chainware.auth.model.CustomUserDetails;
 import com.harusari.chainware.common.dto.ApiResponse;
 import com.harusari.chainware.common.dto.PageResponse;
 import com.harusari.chainware.member.command.application.dto.response.EmailExistsResponse;
@@ -7,6 +8,7 @@ import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
 import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import com.harusari.chainware.member.query.dto.response.MyMemberDetailResponse;
 import com.harusari.chainware.member.query.service.MemberQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -61,7 +64,7 @@ public class MemberQueryController {
                 .body(ApiResponse.success(pageResponse));
     }
 
-    @Operation(summary = "회원 상세 조회", description = "특정 회원의 상세 정보를 조회합니다.")
+    @Operation(summary = "회원 상세 조회 [마스터]", description = "특정 회원의 상세 정보를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 상세 조회 성공")
     })
@@ -75,6 +78,22 @@ public class MemberQueryController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(memberSearchDetailResponse));
+    }
+
+    @Operation(summary = "회원 상세 조회 [회원 본인]", description = "특정 회원의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 상세 조회 성공")
+    })
+    @GetMapping("/members/me")
+    public ResponseEntity<ApiResponse<MyMemberDetailResponse>> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getMemberId();
+        MyMemberDetailResponse myMemberDetailResponse = memberQueryService.getMyProfile(memberId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(myMemberDetailResponse));
     }
 
     @Operation(summary = "회원 로그인 이력 조회", description = "회원의 로그인 이력을 조회합니다.")

--- a/src/main/java/com/harusari/chainware/member/query/dto/response/MyMemberDetailResponse.java
+++ b/src/main/java/com/harusari/chainware/member/query/dto/response/MyMemberDetailResponse.java
@@ -1,0 +1,12 @@
+package com.harusari.chainware.member.query.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MyMemberDetailResponse(
+        Long memberId, String email, String name, String authorityLabelKr,
+        String phoneNumber, LocalDate birthDate, String position
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryCustom.java
@@ -5,6 +5,7 @@ import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
 import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import com.harusari.chainware.member.query.dto.response.MyMemberDetailResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -19,6 +20,8 @@ public interface MemberQueryRepositoryCustom {
     Page<MemberSearchResponse> findMembers(MemberSearchRequest condition, Pageable pageable);
 
     Optional<MemberSearchDetailResponse> findMemberSearchDetailById(Long memberId);
+
+    Optional<MyMemberDetailResponse> findMyMemberDetailById(Long memberId);
 
     Page<LoginHistoryResponse> findLoginHistoryByMemberId(Long memberId, Pageable pageable);
 

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
 import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import com.harusari.chainware.member.query.dto.response.MyMemberDetailResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -99,6 +100,21 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
                         authority.authorityLabelKr, member.phoneNumber,
                         member.birthDate, member.position, member.joinAt,
                         member.modifiedAt, member.isDeleted
+                ))
+                .from(member)
+                .leftJoin(authority).on(member.authorityId.eq(authority.authorityId))
+                .where(member.memberId.eq(memberId))
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<MyMemberDetailResponse> findMyMemberDetailById(Long memberId) {
+        return Optional.ofNullable(queryFactory
+                .select(Projections.constructor(MyMemberDetailResponse.class,
+                        member.memberId, member.email, member.name,
+                        authority.authorityLabelKr, member.phoneNumber,
+                        member.birthDate, member.position
                 ))
                 .from(member)
                 .leftJoin(authority).on(member.authorityId.eq(authority.authorityId))

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryService.java
@@ -5,6 +5,7 @@ import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
 import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import com.harusari.chainware.member.query.dto.response.MyMemberDetailResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -15,6 +16,8 @@ public interface MemberQueryService {
     Page<MemberSearchResponse> searchMembers(MemberSearchRequest memberSearchRequest, Pageable pageable);
 
     MemberSearchDetailResponse getMemberDetail(Long memberId);
+
+    MyMemberDetailResponse getMyProfile(Long memberId);
 
     Page<LoginHistoryResponse> searchMemberLoginHistory(Long memberId, Pageable pageable);
 

--- a/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/service/MemberQueryServiceImpl.java
@@ -6,6 +6,7 @@ import com.harusari.chainware.member.query.dto.request.MemberSearchRequest;
 import com.harusari.chainware.member.query.dto.response.LoginHistoryResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchDetailResponse;
 import com.harusari.chainware.member.query.dto.response.MemberSearchResponse;
+import com.harusari.chainware.member.query.dto.response.MyMemberDetailResponse;
 import com.harusari.chainware.member.query.repository.MemberQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -53,6 +54,12 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     @Override
     public MemberSearchDetailResponse getMemberDetail(Long memberId) {
         return memberQueryRepository.findMemberSearchDetailById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
+    }
+
+    @Override
+    public MyMemberDetailResponse getMyProfile(Long memberId) {
+        return memberQueryRepository.findMyMemberDetailById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND_EXCEPTION));
     }
 


### PR DESCRIPTION
Closes #142 

## 🔥 작업 내용  
- `SecurityPolicy`에서 엔드포인트를 `Permit All`, `Authenticated`, `Role Based` 순서로 변경
- 회원 본인 정보를 수정하는 API 구현
- `@AuthenticationPrincipal CustomUserDetails userDetails`를 컨트롤러에 추가하여, 로그인 사용자가 본인의 정보를 수정할 수 있도록 함
- 서비스 로직에서 회원 정보를 조회해서 JPA 변경 감지 기능으로 회원 정보를 변경하는 기능 구현
- 회원 본인 정보를 조회하는 API 구현
- `@AuthenticationPrincipal CustomUserDetails userDetails`를 컨트롤러에 추가하여, 로그인 사용자가 본인의 정보를 조회할 수 있도록 함
- 회원 정보는 `memberId`, 이메일, 이름, 권한명, 전화번호, 생년월일, 직책 정보를 제공하는 기능 구현

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #142 
