### PR TITLE
ci: PR 자동 리뷰어 및 어싸인 등록 GitHub Actions 추가 (#144)

### DIFF
--- a/.github/pr-auto-assign-config.yml
+++ b/.github/pr-auto-assign-config.yml
@@ -1,0 +1,14 @@
+addAssignees: true
+addReviewers: true
+
+# PR 작성자를 어싸인으로 자동 등록
+assignees:
+  - author
+
+# 자동으로 리뷰어로 등록할 사용자(또는 팀) 리스트 작성
+reviewers:
+  - harusari-chainware/memory-h
+  - harusari-chainware/z00m-1n
+  - harusari-chainware/jang9465
+  - harusari-chainware/Lee-gi-yeun
+  - harusari-chainware/jihye25

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,3 +13,4 @@ jobs:
         uses: kentaro-m/auto-assign-action@v1.2.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: pr-auto-assign-config.yml

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,15 @@
+name: Auto Assign Reviewers and Assignees
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto_assign:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Auto Assign Reviewers and Assignees
+        uses: kentaro-m/auto-assign-action@v1.2.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Closes #144 

## 🔥 작업 내용  
- auto-assign-action 워크플로 (`.github/workflows/auto-assign.yml`) 생성
- reviewers 및 assignees 설정용 `.github/auto_assign.yml` 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ⚙️ 특이사항
- PR를 생성하면 자동으로 리뷰어랑 어싸인인을 등록하는 CI를 구현했습니다.

## ✨ 관련 이슈
- #144 
