### PR TITLE
refactor: 가맹점 수정 기능에 계약 시작일, 종료일을 변경하는 기능 구현

### DIFF
--- a/src/main/java/com/harusari/chainware/franchise/command/application/dto/request/UpdateFranchiseRequest.java
+++ b/src/main/java/com/harusari/chainware/franchise/command/application/dto/request/UpdateFranchiseRequest.java
@@ -4,9 +4,11 @@ import com.harusari.chainware.common.dto.AddressRequest;
 import com.harusari.chainware.franchise.command.domain.aggregate.FranchiseStatus;
 import lombok.Builder;
 
+import java.time.LocalDate;
+
 @Builder
 public record UpdateFranchiseRequest(
-        String franchiseName, String franchiseContact,
-        String franchiseTaxId, FranchiseStatus franchiseStatus, AddressRequest addressRequest
+        String franchiseName, String franchiseContact, String franchiseTaxId, FranchiseStatus franchiseStatus,
+        AddressRequest addressRequest, LocalDate contractStartDate, LocalDate contractEndDate
 ) {
 }

--- a/src/main/java/com/harusari/chainware/franchise/command/application/service/FranchiseCommandServiceImpl.java
+++ b/src/main/java/com/harusari/chainware/franchise/command/application/service/FranchiseCommandServiceImpl.java
@@ -50,7 +50,8 @@ public class FranchiseCommandServiceImpl implements FranchiseCommandService {
 
         franchise.updateFranchise(
                 updateFranchiseRequest.franchiseName(), updateFranchiseRequest.franchiseContact(),
-                updateFranchiseRequest.franchiseTaxId(), updateFranchiseRequest.franchiseStatus(), address
+                updateFranchiseRequest.franchiseTaxId(), updateFranchiseRequest.franchiseStatus(), address,
+                updateFranchiseRequest.contractStartDate(), updateFranchiseRequest.contractEndDate()
         );
 
         if (agreementFile != null && !agreementFile.isEmpty()) {

--- a/src/main/java/com/harusari/chainware/franchise/command/domain/aggregate/Franchise.java
+++ b/src/main/java/com/harusari/chainware/franchise/command/domain/aggregate/Franchise.java
@@ -88,14 +88,17 @@ public class Franchise {
     }
 
     public void updateFranchise(
-            String franchiseName, String franchiseContact,
-            String franchiseTaxId, FranchiseStatus franchiseStatus, Address franchiseAddress
+            String franchiseName, String franchiseContact, String franchiseTaxId,
+            FranchiseStatus franchiseStatus, Address franchiseAddress,
+            LocalDate contractStartDate, LocalDate contractEndDate
     ) {
         this.franchiseName = franchiseName;
         this.franchiseContact = franchiseContact;
         this.franchiseTaxId = franchiseTaxId;
         this.franchiseStatus = franchiseStatus;
         this.franchiseAddress = franchiseAddress;
+        this.contractStartDate = contractStartDate;
+        this.contractEndDate = contractEndDate;
         this.modifiedAt = LocalDateTime.now().withNano(0);
     }
 

--- a/src/test/java/com/harusari/chainware/franchise/command/application/service/FranchiseCommandServiceImplTest.java
+++ b/src/test/java/com/harusari/chainware/franchise/command/application/service/FranchiseCommandServiceImplTest.java
@@ -152,6 +152,8 @@ class FranchiseCommandServiceImplTest {
                 .franchiseTaxId("9876543210")
                 .franchiseStatus(franchise.getFranchiseStatus())
                 .addressRequest(updateAddressRequest)
+                .contractStartDate(LocalDate.parse("2025-06-30"))
+                .contractEndDate(LocalDate.parse("2030-07-07"))
                 .build();
 
         when(franchiseRepository.findFranchiseByFranchiseId(franchiseId)).thenReturn(Optional.of(franchise));
@@ -172,6 +174,7 @@ class FranchiseCommandServiceImplTest {
         assertThat(franchise.getAgreementOriginalFileName()).isEqualTo("contract-update.pdf");
         assertThat(franchise.getAgreementFileSize()).isEqualTo(2048L);
         assertThat(franchise.getAgreementUploadedAt()).isNotNull();
+        assertThat(franchise.getContractEndDate()).isEqualTo("2030-07-07");
     }
 
     @Test

--- a/src/test/java/com/harusari/chainware/franchise/command/domain/aggregate/FranchiseTest.java
+++ b/src/test/java/com/harusari/chainware/franchise/command/domain/aggregate/FranchiseTest.java
@@ -90,7 +90,9 @@ class FranchiseTest {
                 "01099998888",
                 "0987654321",
                 OPERATING,
-                newAddress
+                newAddress,
+                LocalDate.parse("2025-06-29"),
+                LocalDate.parse("2030-08-10")
         );
 
         // then
@@ -100,6 +102,7 @@ class FranchiseTest {
         assertThat(franchise.getFranchiseStatus()).isEqualTo(OPERATING);
         assertThat(franchise.getFranchiseAddress()).isEqualTo(newAddress);
         assertThat(franchise.getModifiedAt()).isNotNull();
+        assertThat(franchise.getContractEndDate()).isEqualTo("2030-08-10");
     }
 
     @Test


### PR DESCRIPTION
Closes #154 

## 🔥 작업 내용  
- `UpdateFranchiseRequest`에 계약 시작일, 종료일 필드 추가
- `Franchise` 엔티티에서 `updateFranchise()` 메서드에 인자값으로 계약 시작일, 종료일을 받도록 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #154 
