### PR TITLE
refactor: AuthController JWT 쿠키 기반 전달 및 인증 플로우 개선

### DIFF
--- a/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
+++ b/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
@@ -1,27 +1,37 @@
 package com.harusari.chainware.auth.controller;
 
 import com.harusari.chainware.auth.dto.request.LoginRequest;
-import com.harusari.chainware.auth.dto.request.RefreshTokenRequest;
+import com.harusari.chainware.auth.dto.response.AccessTokenResponse;
 import com.harusari.chainware.auth.dto.response.TokenResponse;
 import com.harusari.chainware.auth.service.AuthService;
 import com.harusari.chainware.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 @Tag(name = "인증 API", description = "로그인, 로그아웃, 토큰 재발급 API")
 public class AuthController {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String COOKIE_PATH = "/";
+    private static final String SAME_SITE_STRICT = "Strict";
+    private static final boolean HTTP_ONLY = true;
+    private static final long REFRESH_TOKEN_EXPIRATION_DAYS = 7L;
+    private static final long COOKIE_DELETE_MAX_AGE = 0L;
 
     private final AuthService authService;
 
@@ -30,16 +40,14 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공")
     })
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenResponse>> login(
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> login(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "로그인 요청", required = true)
             @RequestBody LoginRequest loginRequest,
             HttpServletRequest httpServletRequest
     ) {
         TokenResponse token = authService.login(loginRequest, httpServletRequest);
 
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(ApiResponse.success(token));
+        return buildTokenResponse(token);
     }
 
     @Operation(summary = "로그아웃", description = "리프레시 토큰을 사용하여 로그아웃을 수행합니다.")
@@ -48,13 +56,14 @@ public class AuthController {
     })
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "리프레시 토큰 요청", required = true)
-            @RequestBody RefreshTokenRequest refreshTokenRequest
+            @Parameter(description = "리프레시 토큰 요청", required = true)
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
     ) {
-        authService.logout(refreshTokenRequest.refreshToken());
+        authService.logout(refreshToken);
+        ResponseCookie deleteCookie = createDeleteRefreshTokenCookie();
 
-        return ResponseEntity
-                .status(HttpStatus.OK)
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
                 .body(ApiResponse.success(null));
     }
 
@@ -63,15 +72,49 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공")
     })
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<TokenResponse>> refresh(
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> refresh(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "리프레시 토큰 요청", required = true)
-            @RequestBody RefreshTokenRequest refreshTokenRequest
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
     ) {
-        TokenResponse tokenResponse = authService.refreshToken(refreshTokenRequest.refreshToken());
+        TokenResponse tokenResponse = authService.refreshToken(refreshToken);
 
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(ApiResponse.success(tokenResponse));
+        return buildTokenResponse(tokenResponse);
+    }
+
+    /* accessToken 과 refreshToken을 body와 쿠키에 담아 반환 */
+    private ResponseEntity<ApiResponse<AccessTokenResponse>> buildTokenResponse(TokenResponse tokenResponse) {
+        ResponseCookie cookie = createRefreshTokenCookie(tokenResponse.refreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(ApiResponse.success(
+                                AccessTokenResponse.builder()
+                                        .accessToken(tokenResponse.accessToken())
+                                        .build()
+                        )
+                );
+    }
+
+    /* refreshToken 쿠키 생성 */
+    private ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(HTTP_ONLY)
+                .secure(false)
+                .path(COOKIE_PATH)
+                .maxAge(Duration.ofDays(REFRESH_TOKEN_EXPIRATION_DAYS))
+                .sameSite(SAME_SITE_STRICT)
+                .build();
+    }
+
+    /* 쿠키 삭제용 설정 */
+    private ResponseCookie createDeleteRefreshTokenCookie() {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(HTTP_ONLY)
+                .secure(false)
+                .path(COOKIE_PATH)
+                .maxAge(COOKIE_DELETE_MAX_AGE)
+                .sameSite(SAME_SITE_STRICT)
+                .build();
     }
 
 }

--- a/src/main/java/com/harusari/chainware/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/harusari/chainware/auth/dto/request/RefreshTokenRequest.java
@@ -1,9 +1,0 @@
-package com.harusari.chainware.auth.dto.request;
-
-import lombok.Builder;
-
-@Builder
-public record RefreshTokenRequest(
-        String refreshToken
-) {
-}

--- a/src/main/java/com/harusari/chainware/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/harusari/chainware/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,9 @@
+package com.harusari.chainware.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AccessTokenResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
@@ -68,6 +68,7 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
                 .where(
                         emailEq(memberSearchRequest.email()),
                         authorityEq(memberSearchRequest.authorityName()),
+                        positionEq(memberSearchRequest.position()),
                         joinDateBetween(memberSearchRequest.joinDateFrom(), memberSearchRequest.joinDateTo()),
                         isDeletedFalse(memberSearchRequest.isDeleted())
                 )
@@ -154,6 +155,10 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
 
     private BooleanExpression authorityEq(MemberAuthorityType authorityName) {
         return authorityName != null ? authority.authorityName.eq(authorityName) : null;
+    }
+
+    private BooleanExpression positionEq(String position) {
+        return position != null ? member.position.eq(position) : null;
     }
 
     private BooleanExpression joinDateBetween(LocalDate from, LocalDate to) {


### PR DESCRIPTION
Closes #169 

## 🔥 작업 내용  
- `AuthController`에서 `refreshToken` 메시지 바디 전달 → HttpOnly 쿠키 전달 구조로 변경
- 로그인 시 `accessToken(body) + refreshToken(cookie)` 전달 구조 구현
- 토큰 재발급 시 쿠키 기반 `refreshToken` 사용 및 `accessToken` 반환 처리
- 로그아웃 시 `refreshToken` 쿠키 삭제 및 상태 초기화 처리


## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #169 
