### PR TITLE
fix: 회원 목록 조회 count 쿼리에 position, isDeleted 조건 추가 

### DIFF
--- a/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/harusari/chainware/member/query/repository/MemberQueryRepositoryImpl.java
@@ -84,7 +84,9 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
                 .where(
                         emailEq(memberSearchRequest.email()),
                         authorityEq(memberSearchRequest.authorityName()),
-                        joinDateBetween(memberSearchRequest.joinDateFrom(), memberSearchRequest.joinDateTo())
+                        positionEq(memberSearchRequest.position()),
+                        joinDateBetween(memberSearchRequest.joinDateFrom(), memberSearchRequest.joinDateTo()),
+                        isDeletedFalse(memberSearchRequest.isDeleted())
                 )
                 .fetchOne();
 


### PR DESCRIPTION
Closes #190 

## 🔥 작업 내용  
- 회원 목록 조회 total count 쿼리에서 누락된 `position`, `isDeleted` 조건 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #190 
