### PR TITLE
feat: 헬스체크 API 추가 및 Redis SSL 프로퍼티명 수정

### DIFF
--- a/src/main/java/com/harusari/chainware/common/controller/HealthCheckController.java
+++ b/src/main/java/com/harusari/chainware/common/controller/HealthCheckController.java
@@ -1,0 +1,17 @@
+package com.harusari.chainware.common.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class HealthCheckController {
+
+    @GetMapping("/health/check")
+    public ResponseEntity<String> healthCheck() {
+        return ResponseEntity.ok("OK");
+    }
+
+}

--- a/src/main/java/com/harusari/chainware/config/RedisConfig.java
+++ b/src/main/java/com/harusari/chainware/config/RedisConfig.java
@@ -24,7 +24,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
-    @Value("${spring.data.redis.ssl:false}")
+    @Value("${spring.data.redis.ssl.enabled:false}")
     private boolean redisSslEnabled;
 
     @Bean

--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -19,6 +19,7 @@ public enum SecurityPolicy {
     // Permit All
     LOGIN_POST("/api/v1/auth/login", POST, PERMIT_ALL, List.of()), // 로그인
     REFRESH_POST("/api/v1/auth/refresh", POST, PERMIT_ALL, List.of()), // 리프레시 토큰 재발급
+    HEALTH_CHECK("/api/v1/health/check", GET, PERMIT_ALL, List.of()), // 헬스 체크
 
     // Authenticated
     LOGOUT_POST("/api/v1/auth/logout", POST, AUTHENTICATED, List.of()), // 로그아웃


### PR DESCRIPTION
Closes #194 

## 🔥 작업 내용  
- 시스템 헬스체크를 위한 `HealthCheckController`를 추가
- 인증 없이 접근할 수 있도록 `/api/v1/health/check`를 `SecurityPolicy`에 등록
- Redis SSL 설정 키가 잘못되어 있어 `${spring.data.redis.ssl:false}` → `${spring.data.redis.ssl.enabled:false}`로 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #194 
