### PR TITLE
fix: 환경별 쿠키 옵션 동적 처리 기능 추가

### DIFF
--- a/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
+++ b/src/main/java/com/harusari/chainware/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -28,10 +29,15 @@ public class AuthController {
 
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
     private static final String COOKIE_PATH = "/";
-    private static final String SAME_SITE_STRICT = "Strict";
     private static final boolean HTTP_ONLY = true;
     private static final long REFRESH_TOKEN_EXPIRATION_DAYS = 7L;
     private static final long COOKIE_DELETE_MAX_AGE = 0L;
+
+    @Value("${app.cookie.secure:true}")
+    private boolean secure;
+
+    @Value("${app.cookie.same-site:none}")
+    private String sameSite;
 
     private final AuthService authService;
 
@@ -99,10 +105,10 @@ public class AuthController {
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                 .httpOnly(HTTP_ONLY)
-                .secure(false)
+                .secure(secure)
                 .path(COOKIE_PATH)
                 .maxAge(Duration.ofDays(REFRESH_TOKEN_EXPIRATION_DAYS))
-                .sameSite(SAME_SITE_STRICT)
+                .sameSite(sameSite)
                 .build();
     }
 
@@ -110,10 +116,10 @@ public class AuthController {
     private ResponseCookie createDeleteRefreshTokenCookie() {
         return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
                 .httpOnly(HTTP_ONLY)
-                .secure(false)
+                .secure(secure)
                 .path(COOKIE_PATH)
                 .maxAge(COOKIE_DELETE_MAX_AGE)
-                .sameSite(SAME_SITE_STRICT)
+                .sameSite(sameSite)
                 .build();
     }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -74,3 +74,8 @@ server:
       force: true
   error:
     include-stacktrace: never
+
+app:
+  cookie:
+    secure: true
+    same-site: None

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,3 +78,8 @@ springdoc:
     enabled: true
     tags-sorter: alpha
     operations-sorter: alpha
+
+app:
+  cookie:
+    secure: false
+    same-site: Strict


### PR DESCRIPTION
Closes #200 

## 🔥 작업 내용  
- 배포 환경과 개발 환경에 따라 리프레시 토큰의 쿠키 설정(Secure, SameSite)을 동적으로 처리하도록 쿠키를 환경별로 다르게 설정하는 기능을 추가
- `application.yml`, `application-prod.yml`에 환경별 쿠키 옵션 추가
- `@Value` 어노테이션으로 쿠키 설정값 주입
- `createRefreshTokenCookie` 및 `createDeleteRefreshTokenCookie`에서 쿠키 설정을 동적으로 처리하도록 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #200 
