### PR TITLE
ci: ECS 배포 파이프라인에 S3 Task Definition 경로 환경변수화

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -11,6 +11,7 @@ env:
   ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
   CONTAINER_NAME: ${{ secrets.CONTAINER_NAME }}
   AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+  TASK_DEF_S3_KEY: ${{ secrets.TASK_DEF_S3_KEY }}
 
 permissions:
   contents: read
@@ -61,7 +62,7 @@ jobs:
 
       - name: Download task definition from S3
         run: |
-          aws s3 cp s3://${{ env.AWS_S3_BUCKET_NAME }}/env/ecs/task-definitions/chainware-spring-task-definition.json .aws/task-definition.json
+          aws s3 cp s3://${{ env.AWS_S3_BUCKET_NAME }}/${{ env.TASK_DEF_S3_KEY }} .aws/task-definition.json
 
       - name: Check task definition exists
         run: test -s .aws/task-definition.json


### PR DESCRIPTION
Closes #203 

## 🔥 작업 내용  
- 환경변수 `TASK_DEF_S3_KEY`를 GitHub Secrets에 추가
- GitHub Actions 워크플로우 내 S3 다운로드 경로를 환경변수로 변경
- ECS 배포 파이프라인 수정 및 환경변수 적용 완료

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #203 
