### PR TITLE
refactor: CORS 허용 Origin을 환경변수 기반으로 개발·운영 환경 분리

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityConfig.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.harusari.chainware.auth.jwt.JwtTokenProvider;
 import com.harusari.chainware.auth.jwt.RestAccessDeniedHandler;
 import com.harusari.chainware.auth.jwt.RestAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,10 +25,15 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private static final String ORIGIN_DELIMITER = ",";
+
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
     private final RestAccessDeniedHandler restAccessDeniedHandler;
     private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -72,14 +78,18 @@ public class SecurityConfig {
         return new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
     }
 
-    // TODO: 좀 더 좋은 코드로 바꿀 수 있을 듯?
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:5173");
+
+        for (String origin : allowedOrigins.split(ORIGIN_DELIMITER)) {
+            config.addAllowedOrigin(origin.trim());
+        }
+
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         config.setAllowCredentials(true);
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -79,3 +79,6 @@ app:
   cookie:
     secure: true
     same-site: None
+
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,3 +83,6 @@ app:
   cookie:
     secure: false
     same-site: Strict
+
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION
Closes #212 

## 🔥 작업 내용  
- CORS 허용 Origin을 환경변수로 관리하여 개발과 운영 환경에 따라 유연하게 CORS 설정이 적용되도록 변경

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #212 
