### PR TITLE
fix: SecurityPolicy에 잘못 등록된 비밀번호 변경 엔드포인트 수정

### DIFF
--- a/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
+++ b/src/main/java/com/harusari/chainware/config/security/SecurityPolicy.java
@@ -23,7 +23,7 @@ public enum SecurityPolicy {
 
     // Authenticated
     LOGOUT_POST("/api/v1/auth/logout", POST, AUTHENTICATED, List.of()), // 로그아웃
-    PASSWORD_POST("/api/v1/auth/password", POST, AUTHENTICATED, List.of()), // 비밀번호 변경
+    PASSWORD_PUT("/api/v1/members/password", PUT, AUTHENTICATED, List.of()), // 비밀번호 변경
     MEMBERS_ME_GET("/api/v1/members/me", GET, AUTHENTICATED, List.of()), // 회원 정보 조회
     MEMBERS_ME_PUT("/api/v1/members/me", PUT, AUTHENTICATED, List.of()), // 회원 정보 수정
 


### PR DESCRIPTION
Closes #231 

## 🔥 작업 내용  
- `/api/v1/auth/password`에서 `/api/v1/members/password`으로 수정 
- `HttpMethod` `POST`에서 `PUT`으로 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #231 
